### PR TITLE
Add crash rate analysis

### DIFF
--- a/aurora/e10s_crash_rate.ipynb
+++ b/aurora/e10s_crash_rate.ipynb
@@ -1,0 +1,1142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### E10S Experiment Aurora (crash rate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Bug 1222890](https://bugzilla.mozilla.org/show_bug.cgi?id=1222890)\n",
+    "\n",
+    "This analysis tracks crash rate differences between e10s and non-e10s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unable to parse whitelist (/home/hadoop/anaconda/lib/python2.7/site-packages/moztelemetry/bucket-whitelist.json). Assuming all histograms are acceptable.\n",
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ujson as json\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.plotly as py\n",
+    "import IPython\n",
+    "\n",
+    "from __future__ import division\n",
+    "from moztelemetry.spark import get_pings, get_one_ping_per_client, get_pings_properties\n",
+    "from montecarlino import grouped_permutation_test\n",
+    "\n",
+    "%pylab inline\n",
+    "IPython.core.pylabtools.figsize(16, 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "128"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.defaultParallelism"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Get e10s and non-e10s partitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def is_in_e10s_experiment(ping):\n",
+    "    try:\n",
+    "        experiment = ping[\"environment\"][\"addons\"][\"activeExperiment\"]\n",
+    "        return experiment[\"id\"] == \"e10s-enabled-aurora-20151020@experiments.mozilla.org\" and \\\n",
+    "               (experiment[\"branch\"] == \"control\" or experiment[\"branch\"] == \"experiment\")   \n",
+    "    except:\n",
+    "        return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def is_e10s_ping(ping):\n",
+    "    return ping[\"environment\"][\"settings\"][\"e10sEnabled\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def strip_date(date):\n",
+    "    return date[:10].replace(\"-\", \"\")\n",
+    "\n",
+    "def is_sensible_creation_date(ping):\n",
+    "    creation_date = strip_date(ping[\"creationDate\"])\n",
+    "    submission_date = strip_date(ping[\"meta\"][\"submissionDate\"])\n",
+    "    return creation_date == submission_date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "PER_ADI = 100\n",
+    "PING_OPTIONS = { \"app\": \"Firefox\", \"channel\": \"aurora\", \"version\": \"43.0a2\", \"submission_date\": (\"20151023\", \"20151027\") }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "session_pings = get_pings(sc, **PING_OPTIONS).filter(is_in_e10s_experiment).filter(is_sensible_creation_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make sure it's not the first session ping as the experiment branch will not be enforced until the next restart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# TODO: Add get_ping_properties to moztelemetry?\n",
+    "def get_ping_properties(ping, paths, only_median=False, with_processes=False):\n",
+    "    from moztelemetry.spark import _get_ping_properties\n",
+    "    if type(paths) == str:\n",
+    "        paths = [paths]\n",
+    "\n",
+    "    # Use '/' as dots can appear in keyed histograms\n",
+    "    paths = [(path, path.split(\"/\")) for path in paths]\n",
+    "    return _get_ping_properties(ping, paths, only_median, with_processes)\n",
+    "\n",
+    "first_session_ping_of_client = \\\n",
+    "      session_pings.map(lambda p: (p[\"clientId\"], p))\\\n",
+    "     .reduceByKey(lambda x, y: x if x[\"meta\"][\"creationTimestamp\"] < y[\"meta\"][\"creationTimestamp\"] else y)\\\n",
+    "     .map(lambda p: (p[0], get_ping_properties(p[1], [\"meta/documentId\", \"meta/creationTimestamp\"])))\\\n",
+    "     .collectAsMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def not_first_session(ping):\n",
+    "    return not ping[\"meta\"][\"documentId\"] in first_session_ping_of_client[ping[\"clientId\"]][\"meta/documentId\"]\n",
+    "\n",
+    "session_pings = session_pings.filter(not_first_session)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "e10s_session_pings = session_pings.filter(lambda p: is_e10s_ping(p))\n",
+    "non_e10s_session_pings = session_pings.filter(lambda p: not is_e10s_ping(p))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many crashes did we have in total?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "crash_pings = get_pings(sc, doc_type=\"crash\", **PING_OPTIONS).filter(is_in_e10s_experiment).filter(is_sensible_creation_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5872"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crash_pings.count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many crash pings don't have a clientId?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def has_client_id(ping):\n",
+    "    return ping.get(\"clientId\")\n",
+    "\n",
+    "crash_pings.filter(lambda p: not has_client_id(p)).count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Exclude them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "crash_pings = crash_pings.filter(has_client_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many crash pings occured before the first session ping?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1171"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def is_after_first_session_timestamp(ping):\n",
+    "    first_session_ping = first_session_ping_of_client.get(ping[\"clientId\"])\n",
+    "    return first_session_ping and ping[\"meta\"][\"creationTimestamp\"] > first_session_ping[\"meta/creationTimestamp\"]\n",
+    "\n",
+    "crash_pings.filter(lambda p: not is_after_first_session_timestamp(p)).count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Exclude them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "crash_pings = crash_pings.filter(is_after_first_session_timestamp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "e10s_crash_pings = crash_pings.filter(lambda p: is_e10s_ping(p))\n",
+    "non_e10s_crash_pings = crash_pings.filter(lambda p: not is_e10s_ping(p))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Crashes per ADI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_crash_rate_per_day(sessions, crashes):\n",
+    "    sessions_per_day = sessions.map(lambda p: (strip_date(p[\"creationDate\"]), 0)).countByKey()\n",
+    "    crashes_per_day = crashes.map(lambda p: (strip_date(p[\"payload\"][\"crashDate\"]), 0)).countByKey()\n",
+    "    return { k: (float(crashes_per_day.get(k, 0)) / sessions_per_day.get(k, 1)) * PER_ADI for k in set(sessions_per_day) }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "e10s_crash_rate_per_day = get_crash_rate_per_day(e10s_session_pings, e10s_crash_pings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "non_e10s_crash_rate_per_day = get_crash_rate_per_day(non_e10s_session_pings,  non_e10s_crash_pings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": [
+       "iVBORw0KGgoAAAANSUhEUgAAA8UAAAG3CAYAAACdR/ePAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\n",
+       "AAALEgAACxIB0t1+/AAAIABJREFUeJzs3XecZGWV+P/PISogcUQZgiNIUEQQTBjRXcUVdXVNGNa4\n",
+       "rqKsWVdd9XL1p1+zrq5iWBUMgFkXdFUMuCoiq5JBgghLziA5nt8f9zbT01Pd1VPTVbee6s/79apX\n",
+       "16263XWK08306ec590RmIkmSJEnSYrRG1wFIkiRJktQVi2JJkiRJ0qJlUSxJkiRJWrQsiiVJkiRJ\n",
+       "i5ZFsSRJkiRp0bIoliRJkiQtWkMriiNi64j4RUScEhEnR8RrZjnvExFxZkScEBEPHFY8kiRJkiTN\n",
+       "tNYQv/atwOsz8/iI2AD4Q0QcmZmnTZ0QEU8C7pOZ20fEQ4EDgYcNMSZJkiRJku40tJXizLw4M49v\n",
+       "718HnAYsnXHaU4GD23N+B2wcEfcYVkySJEmSJE03kp7iiFgGPBD43YyntgTOm3Z8PrDVKGKSJEmS\n",
+       "JGnoRXG7dfpbwGvbFeOVTplxnMOOSZIkSZIkGG5PMRGxNvBt4KuZ+b0ep1wAbD3teKv2sZlfx0JZ\n",
+       "kiRJkiZYZs5cMB2JoRXFERHAF4BTM/Pjs5z2X8D+wGER8TDg6sy8pNeJXf0H0uqJiAMy84Cu49Bg\n",
+       "zF/ZzF+5zF3ZzF+5zF3ZzF/ZulwIHeZK8SOAFwAnRsRx7WNvB7YByMzPZuYPI+JJEXEWcD3wkiHG\n",
+       "o24s6zoArZZlXQeg1bKs6wA0sGVdB6DVsqzrADSwZV0HoNWyrOsAVKahFcWZ+Wvm0bOcmfsPKwZJ\n",
+       "kiRJkuYykqtPa1E7qOsAtFoO6joArZaDug5AAzuo6wC0Wg7qOgAN7KCuA9BqOajrAFSmyBz/a1hF\n",
+       "RNpTLI1G1LE2sC1wX2B94Ippt8uBa7Mq4H8ckiRJKkaXNZ9FsYYqIvbKzKO6jkMrizo2AHakKX7v\n",
+       "C+zUftyW5irwp3Eyd+X+3A5s1t6WAOsAV7K8SL6ix/2Zx1dllbeP7M0J8OevZOaubOavXOaubP3y\n",
+       "50Sb8dGrtuuy5hvqSCZJ3Yo6AticFYveqY9LgDOAPwGnAV9v75+RVd4E7T8u31zxH5eoY11WLJKn\n",
+       "318K7NLjuQ2jjmuYXwF953FWecsC/yeRJEmLmAtt3RvHP064UixNgKhjTZorLk4veqfuJ03RO1X8\n",
+       "Tt0/d1Srt1HHWsAm9C6mZzveFLiJVVuRvgK43u3dkiRpJmuK8TBbHtw+3YffwFIj6rgrsAMrb3ne\n",
+       "HriUFYveqY+XlVgktqvcG9J7RXq2gnoJEKziijRwTVZ5x4jemiRJ6oA1xXiwKB6Q38DlsjdnMFHH\n",
+       "Zqy84ntfYAvgz6xY9J4GnJ5VXr/gcRSYv6hjPeYumns9tz5wFau2In1lVnnrqN7XIErMnxrmrmzm\n",
+       "r1zmrmzz6Sm2pujeOBbF9hRLHYk61gC2pne/77qsWPT+sr1/dlZ5WycBFyKrvAG4AThvvp/TXnF7\n",
+       "U3oXzUtoLkg287lNoo7rWLUV6SuyyhtX+01KkiRpwbhSLA1Z1LEOzfbmmf2+OwJX07vf96IStzwv\n",
+       "Ju0fNTZm/tu6p+7fxjwL6GnHjsGSJGk1lVpTRMT9gY8AuwObZeYaM57fFPgC8Hia3xvelpmHjjzQ\n",
+       "eRrHlWKLYmmBRB0b0XvL8zbAufTo980q/9pNtOpC2ye9PvMvoGeOwZr3ijSOwZIkaQWl1hQRsQPw\n",
+       "CJp/37/XoyieKoBfBjwQ+AHw8Mw8daSBzpNF8YBK/QbW5PXmtEXNUnoXvxvSFLwz+33PKnW00KTl\n",
+       "r1RzjMGaq6DekLO5nm25hP4F9PTt3UV+r04af/bKZv7KZe7KVnpPcUQsBT4JPAq4DvhYZn5y2vP3\n",
+       "Ac6YXhRHxPo0fzjfOTPPah87GLgwM98WEUuAg2iK6juAU4DHZIdF4DgWxfYUSz20I4S2o/eIoxtZ\n",
+       "sej9fnv/fK9grGHIKm8GLmxv8xJ1rMWR7MMrOJ3eRfO9Wbmg3jTquIl5FtDTjm9we7ckSYOLiDWA\n",
+       "w4HvAs+hue7MTyPi9Mz8yRyfugNw21RB3DoB2Ku9/0aa66wsaY8f1mVBPK5cKdaiFnVsQNPbO7P4\n",
+       "3Ra4gN5bnq/sJlppuOYYg9XveA3mt6V7+n3HYEmSRmqca4qIeCjwjcy817TH3gZsn5kvbY97rRQ/\n",
+       "qv28LaY99nLgeZn52IiogV2BN2bmn0f0dubkSrHUgfYX/c3pveV5CXAmy4vfb7Qfz8gqb+okYKkj\n",
+       "7WrvNe3t7Pl+Xp8xWPcC9ujx/PpRx5Ws2or0lV59XZI0TBGs9ophJoMUdvcClkbEVdMeWxP4nz6f\n",
+       "dx3NH7Sn2wi4tr3/IeAA4CcRAfC5zPzAAPFNNFeKNVSj7M2JOtYEltG7+E16X+X5XC9GNDt7q8o2\n",
+       "zvnrMwZrtuNNaP7xX5UV6SLHYI1z7tSf+SuXuStbyT3FEfEw4MuZucMc58y3p/grwHmZ+fYZn78z\n",
+       "8HPguZn58yG8jXlxpVhaAFHHXWn6J2Zueb4PcBnLC95jgYPb+5fZ8yiNj6zyVuCS9jYv8xiDtRs9\n",
+       "CuqoY64xWLMV147BkiSN0rHAtRHxFpqLbd1C8/vtXTLz9xFxF5ppFETEugCZeXNmXh8R3wHeHRH/\n",
+       "RDO26SnAnu25+wCnA38G/grc3t40jSvFGltRx2YsL3qnF79b0GztnNnve3pWeX030UoaR9PGYM1n\n",
+       "9NX043VZeQxWv5FYjsGSpDE27jVFRGxBM4/4sTT/Dv0JeAfN771TbU0JBHBOZm7bft4mwBdZPqf4\n",
+       "rZl5WPvc64DXAncHrgI+k5nvHdV76mUcV4otitWpduVna3pveV6XGRe5aj+ebV+hpGFahTFY0483\n",
+       "pOnHXpUVacdgSdKIWFOMB4viAfkNXK6p3o6oYx1ge1Ze9d0RuJre/b4XuX2xW/ZWlc38jVZ7XYNN\n",
+       "mP8s6anbymOwjuVaHsLrSuyHlj97JTN3ZSu5p3gxGcei2J5iLaioYyOmb3l+No+MOjYHtgHOZXnB\n",
+       "+xPg32m2PF/TVbyStFDardOXt7d5mTEGa3nRvD4vB06KOl6dVf54GPFKkqSGK8VaZe0vcUvpveV5\n",
+       "Q5pm/pn9vme5RVCS5i/qeBLwHzQXX3lDVnlhxyFJUtGsKcbDOK4UWxRrVlHHWsB2rFz87kSz3a/X\n",
+       "lufzs8o7OglYkiZMOwP634B/BmrgQC/mJUmDsaYYDxbFA/IbeLiijg1oenunr/juBGwLXEiP4jer\n",
+       "vHJeX9venKKZv7KZv3LNzF3UcT/gQJorab8yq/x9V7GpP3/2ymXuymZPcRnGsSi2p3iRaLc8b07v\n",
+       "EUdLgDNZXvR+o/14phd5kaTuZZWnRh17AS8Ejog6vgm8w2sySJK0+lwpnjDt1U+X0bvfF5YXvtNX\n",
+       "f891O54klaGd4f5+4EnA64FveqV+SerPmmI8jONKsUVxoaKOuwI7sHLxuz1wGb3n+17mL06SNBmi\n",
+       "jkcAnwEuAF6dVf6545AkaaxZU4wHi+IBLeZv4KhjU1Ze8b0vzdWf/8zK/b5nZJXXdRPtyuzNKZv5\n",
+       "K5v5K9d8cxd1rA28DvhXmjF3H8wqbx5yeOrDn71ymbuy2VNchnEsiu0pHgNRxxrA1vTu912XFYve\n",
+       "X7Ufz84qb+skYEnSWMgqbwU+FHV8A/gkcELU8aqs8ucdhyZJKkxEPBZ4F/BA4KrMvPeM55cBXwIe\n",
+       "AvwfsH9m/mzEYQ6FK8UjFHWsQ7O9eeaW5x2Ba+i95fkitzxLkuYj6vh7muL4l8Abs8pLOw5JksbG\n",
+       "pNQUwxIRD6Zpz1wPeHuPovi3wG9oRgXuA3wB2D4zL1/F1xm7lWKL4iGIOjZi5VXfnYB7Aeey8pbn\n",
+       "072CqCRpIbRj9irgRcA7gP90frwkjXdNERHn0PxR84U0NcOPgBdl5s0R8XLgLcCmwK+BV2bmRe3n\n",
+       "3QHsB7wRuDvwtczcf47X2al9nd1prkP0zsz85oxz/hb4/PSiOCJ2AE4ENsvM69vHfgkckpmfjYj7\n",
+       "0BTJuwK3Aj/LzH1niWHsimK3Tw+oHXG0Bb37fTcETmd50fvl9uNZWeUtnQTcEXtzymb+ymb+yrU6\n",
+       "uWuvK/HmqOMrNBfieknU8cqs8oSFjFGz82evXOaubIXnL4FnAXsDN9OsyL44Is4E3gc8HjgV+DBw\n",
+       "GPCYaZ+7D/AgYCPgDxFxeGb+eOYLRMT6wJE0fzDdG3gAcGREnJyZp/WJb2fg7KmCuHVC+zjAe4Af\n",
+       "ZeZjImKdNp5iWBT3EXWsBWxH75Xfm1hxxffw9uP5/lVektSlrPLEqOORwMuAI9siuRqnizFKklbw\n",
+       "icy8GCAiDgd2Ax4MfCEzj28ffxtwVURsk5n/137e+zPzr8BfI+IX7eetVBQDTwb+kpkHt8fHR8R3\n",
+       "aIrxd/eJbQOads/prqVZJAS4BVgWEVtm5gXA0fN7y+PBorgVdaxPU+jO7PfdFriQ5VuefwV8Hjgt\n",
+       "q7yym2jLUfBf64T5K535K9dC5a79A+3no47vAx8CTo06Xgt8z+tVDI8/e+Uyd2VbiPxFHav9/8as\n",
+       "Bt4CfPG0+zfQTJvZDPjjnV878/qIuALYkuZiV70+b32AiDgF2IZmFfpJNNuyHxoRV007fy2aXa39\n",
+       "XEezG3a6jWgKY2i2d78HOLb9+h/JzC/N4+uOhUVVFLdbnu9O7y3PS4AzWV78fqO9f2ZWeWMnAUuS\n",
+       "tADaC269KOp4LHAg8NKoY/+s8tyOQ5OksbIaBe2wXEhTzAJ3boHejGZG/WwCIDN3XuHBiK2AX2bm\n",
+       "EwaI4xRg24jYIPPOHUe7Al9pX+sS4J/b13kE8NOI+GVmnj3Aa43cRBbFUceaNN88vYpfWL7d+TSa\n",
+       "ffWnAedmlbePPtrJVnhvx6Jn/spm/so1rNxllb+IOnYF3gT8Ier4IPCxdrSTFog/e+Uyd2WbsPxN\n",
+       "FeeHAodGxCE0C3fvA46ZtnV6ts/r5Qjg/RHxAuDr7WO7Addm5p8iImjGwa4NRESsC2Rm3pKZZ0TE\n",
+       "8UAVEe+kWXm+P/BtmpOfBfw2M88HrqZZnS6mnbToojjquCvNZcNnbnnenuZqalP9vv9L81eM04DL\n",
+       "3DImSVqsssqbgfdGHYcBnwJe2F6I69cdhyZJWi5pCtKftUXot4FNaC7Ate+M81b6vJ5fMPO6iHgC\n",
+       "8NH2tgZwPPCG9pTHAFNz7hO4ETgKeFz72L7AQcCVNBN1npGZV7TPPQj4WERsBFwCvCYzz1mld9yh\n",
+       "YkYycQCPZOULXS0FzmblEUdneCERSZLm1rYVPRP4OM34j3/NatXmTUpSKcZ5JNNiMo4jmUoqio9l\n",
+       "edE7VQD/xS1fkiStnqhjQ5oLpOwLvBU4yF1VkiaNRfF4sCgekN/A5Zqw3o5Fx/yVzfyVq6vcRR17\n",
+       "0Mw2vhHYL6s8ZdQxTAJ/9spl7srWL3/WFONhHIviNbp4UUmSNH6yyj8AD6O5AMtRUcf7oo71Og5L\n",
+       "kqShcqVYkiStJOrYguZCLA8D9s8qf9BxSJK0WqwpxsM4rhRbFEuSpFlFHU8APg2cALw2qzy/45Ak\n",
+       "aSDWFONhHItit09rqCJir65j0ODMX9nMX7nGKXdZ5U+AXYCTgeOjjtdHHUWPdBy2ccqfVo25K5v5\n",
+       "06AsiiVJ0pyyyhuzygp4BPBk4PdRx0M7DkuSpAXh9mlJkjRv7Wzj5wEfBr4LvD2rvLrbqCSpv4gY\n",
+       "/8JnkRi37dMWxZIkaZVFHZsA7wOeBrwJOMTZxpKkQdlTrIllb0fZzF/ZzF+5SshdVnlVVrkf8HTg\n",
+       "zcBPo44dOw5rLJSQP/Vm7spm/jQoi2JJkjSwrPIY4EHAEcBvoo466rhLx2FJkjRvbp+WJEkLIurY\n",
+       "Gvg48ADgVVnlkR2HJEkqhD3FfVgUS5JUjqjjycAngd8Cb8gqL+44JEnSmLOnWBPL3o6ymb+ymb9y\n",
+       "lZ67rPIIYGfgXOCkqOPVUceaHYc1MqXnbzEzd2UzfxqURbEkSVpwWeUNWeXbgL2AfYFjoo7du41K\n",
+       "kqSVuX1akiQNVdSxBvAi4P3AYcA7s8q/dhuVJGmc2FPch0WxJEnlizqWAB8A9gZeD3zL2caSJLCn\n",
+       "WBPM3o6ymb+ymb9yTWrussrLs8qXAc8FKuCHUce2HYe14CY1f4uBuSub+dOgLIolSdJIZZW/AnYH\n",
+       "jgKOjTr+LepYt9uoJEmL1VC3T0fEF4F9gEszc5cezy8BvgrcE1gL+HBmHtTjPLdPS5I0gaKOZTTj\n",
+       "m+4D7JdVHtVlPJKkbkxsT3FEPAq4DvjyLEXxAcC6mfm2tkA+HbhHZt424zyLYkmSJlTUEcDTgE8A\n",
+       "PwfenFVe2m1UkqRRmtie4sz8FXDVHKdcBGzY3t8QuGJmQayy2dtRNvNXNvNXrsWWu6wys8rvAvcD\n",
+       "LgdOjjpe3l61ujiLLX+TxNyVzfxpUF3/Y/N5YOeIuBA4AXhtx/FIkqSOZJXXZpVvBJ4AvAz4ddTx\n",
+       "gI7DkiRNuKGPZIqIZcDhs2yffgewJDNfFxHbAUcCu2bmtTPOc/u0JEmLSLtK/HLgPcDBQJ1VXtdt\n",
+       "VJKkYemy5lurixed5uHAewEy888R8RdgR+D3M0+MiIOAc9rDq4HjM5uLcUxtlfDYY4899thjjyfj\n",
+       "OKu8IyJOZ0tewct5OnBKPDo+x6/4zTjE57HHHnvs8Wof7wZsTGMZHep6pfijwDWZWUfEPYA/AA/I\n",
+       "zCtnnJfpSnGRImKvqW9+lcf8lc38lcvcrSzqeBxwIPAn4DVZ5bkdhzQr81cuc1c281e2Lmu+ofYU\n",
+       "R8ShwNHAjhFxXkS8NCJeERGvaE95H/CgiDgB+CnwlpkFsSRJUlb5c+ABNLvJ/hB1vDnqWLvjsCRJ\n",
+       "E2DoK8ULwZViSZI0Jeq4D/ApYCnwyqzyNx2HJElaTV3WfBbFkiSpOO1s42cDHwV+CLw1q7yi26gk\n",
+       "SYOa2O3T0lRTvcpk/spm/spl7vprZxt/nWa28Y3AKVHHi9piuVPmr1zmrmzmT4OyKJYkScXKKq/J\n",
+       "Kl8DPBl4DfCLqOO+HYclSSqI26clSdJEiDrWBF4FVMBngfdmlTd0G5UkaT7sKe7DoliSJM1X1LEU\n",
+       "+BjwYODVWeV/dxySJKkPe4o1seztKJv5K5v5K5e5Wz1Z5YVZ5XOA/YBPRh3fjDq2HNXrm79ymbuy\n",
+       "mT8NyqJYkiRNpKzyx8AuwGnACVHHa6OOtToOS5I0Ztw+LUmSJl7UsRPwaWBjmtnGx3YckiRpGnuK\n",
+       "+7AoliRJq6sd1/R84EPAd4B/yyqv7jYqSRLYU6wJZm9H2cxf2cxfuczdcLSzjb8K7AysBZwadTx3\n",
+       "oWcbm79ymbuymT8NyqJYkiQtKlnllVnlK4BnAG8FfhJ1bN9xWJKkjrh9WpIkLVrthbdeA7wd+CTw\n",
+       "gazypm6jkqTFx57iPiyKJUnSMEUdWwP/DtwfeFVW+dOOQ5KkRcWeYk0sezvKZv7KZv7KZe5GL6s8\n",
+       "L6v8B+CNwH9GHV+LOu45yNcyf+Uyd2UzfxqURbEkSVIrqzyc5kJc5wEnRR37RR1rdhyWJGmI3D4t\n",
+       "SZLUQ9Rxf+AzwNo0s42P6zgkSZpY9hT3YVEsSZK6EHWsAbwY+H/AIcC7ssprOw1KkiaQPcWaWPZ2\n",
+       "lM38lc38lcvcjY+s8o6s8os0W6o3oplt/Iy5Zhubv3KZu7KZPw3KoliSJKmPrPLyrPKlwPOB9wBH\n",
+       "RB337jgsSdICcPu0JEnSKog61gHeALwJ+Ajwkazylm6jkqSy2VPch0WxJEkaN+1K8X8A96a5ENf/\n",
+       "dBySJBXLnmJNLHs7ymb+ymb+ymXuypBV/gV4MvAO4GtRx5eijrubv3KZu7KZPw3KoliSJGlAWWVm\n",
+       "ld8B7gdcBZzM3/Kk9qrVkqQCuH1akiRpgUQdD6SZbXwrzZbqkzsOSZKKYE9xHxbFkiSpFFHHmsDL\n",
+       "aa5S/UXg3Vnl9d1GJUnjzZ5iTSx7O8pm/spm/spl7gp3AI/KKj8D7AJsCZwSdTyl46g0D/7slc38\n",
+       "aVAWxZIkSUOQVV6cVb4AeBnwkajju1HHNl3HJUlakdunJUmShizquAvwFuA1wP8DPpFV3tptVJI0\n",
+       "Puwp7sOiWJIkTYKoY3vgU8A9aC7E9duOQ5KksWBPsSaWvR1lM39lM3/lMndlmyt/WeWZwN40q8Xf\n",
+       "jjo+G3VsOqrYNDd/9spm/jQoi2JJkqQRamcbH0Yz2/hWmgtx/WPU4a44SeqA26clSZI6FHU8GPgs\n",
+       "cA2wX1b5p45DkqSRs6e4D4tiSZI0yaKOtYBXAe8CDgTel1Xe2G1UkjQ69hRrYtnbUTbzVzbzVy5z\n",
+       "V7ZB8pdV3pZVfgLYFdgRODnqeOJCx6a5+bNXNvOnQVkUS5IkjYms8oKs8tnA/sCno46vRx1Lu45L\n",
+       "kiaZ26clSZLGUNSxHvB24BXAu4FPZ5W3dxuVJA2HPcV9WBRLkqTFKuq4L02f8QY0s41/33FIkrTg\n",
+       "7CnWxLK3o2zmr2zmr1zmrmwLnb+s8jTgscAngCOijk9GHRst5Guo4c9e2cyfBmVRLEmSNOba2cZf\n",
+       "ppltvC5watSxr7ONJWn1uX1akiSpMFHHw4HPABcBr84qz+o4JElaLfYU92FRLEmStKKoY23gtcBb\n",
+       "gX8HPphV3txtVJI0GHuKNbHs7Sib+Sub+SuXuSvbqPKXVd6aVX4Y2B3YAzgx6njcKF57UvmzVzbz\n",
+       "p0FZFEuSJBUsq/y/rPJpwFuAL0UdX4k67tF1XJJUCrdPS5IkTYioYwPgXcCL24+fyyrv6DQoSZoH\n",
+       "e4r7sCiWJEmav6hjF5oLca0JvCKrPKHjkCRpTvYUa2LZ21E281c281cuc1e2cchfVnkS8CjgP4Ej\n",
+       "o46PRB136zissTcOudPgzJ8GZVEsSZI0gbLKO7LK/wR2BjYDTok6nu5sY0lakdunJUmSFoGoYy/g\n",
+       "QOAs4F+yynM6DUiSpnH7tCRJkoYqqzwK2BX4LfD7qOOtUcc63UYlSd2zKNZQ2dtRNvNXNvNXLnNX\n",
+       "tnHOX1Z5S1b5PuAhwKOBP0Ydj+o4rLExzrlTf+ZPg7IoliRJWmSyyrOBfYAKOCTq+ELUsaTjsCSp\n",
+       "E/YUS5IkLWJRx4bAu4HnAm8FDna2saRRc05xHxbFkiRJwxV17E4z2/gmYL+s8pSOQ5K0iHihLU0s\n",
+       "ezvKZv7KZv7KZe7KVmr+sso/AnsChwFHRR3vjzrW7ziskSo1d2qYPw3KoliSJEkAZJW3Z5WfBnYB\n",
+       "tgZOjjr26TgsSRoqt09LkiSpp6jjb4FPAycBr80qz+84JEkTamK3T0fEFyPikog4aY5z9oqI4yLi\n",
+       "5Ig4apjxSJIkaf6yyp8CD6Apio+POl4fdazVcViStKCGvX36S8ATZ3syIjYGPgU8JTPvDzxzyPFo\n",
+       "xOztKJv5K5v5K5e5K9uk5S+rvCmrPAB4OM0Yp99HHQ/rNqrhmLTcLTbmT4MaalGcmb8CrprjlOcB\n",
+       "385stuJk5uXDjEeSJEmDySrPAB4PfBD4TtTxmahjk47DkqTVNvSe4ohYBhyembv0eO5jwNrAzsDd\n",
+       "gH/PzK/0OM+eYkmSpDERdWwMvBf4B+DNwNeyKuBCNZLG1kTPKe5TFP8HsDvwN8B6wG+BfTLzzBnn\n",
+       "WRRLkiSNmajjIcBngSuBV2WVp3cckqRCdVnzdX2hhPOAyzPzRuDGiPgfYFfgzJknRsRBwDnt4dXA\n",
+       "8Zl5VPvcXgAej9/x9N6OcYjHY/O3mI7NX7nHU4+NSzwem7853+8BPBjYn7M5Np4a32UPXplV3jQu\n",
+       "8a3i8W6Z+fExisdj8zfJx7sBG9NYRoe6XineCfgPYG9gXeB3wHMy89QZ52W6UlykiNhr6ptf5TF/\n",
+       "ZTN/5TJ3ZVus+Ys6tgI+TvOL7quyyp90HNIqW6y5mxTmr2xd1nxDLYoj4lDgMcAS4BKgoukhJjM/\n",
+       "257zJuAlwB3A5zPzEz2+jkWxJElSAaKOJ9EsehwLvD6rvKjjkCQVYGKL4oViUSxJklSOqGM94N+A\n",
+       "fwZq4MCs8vZuo5I0zrqs+YY9p1iL3PT+KpXH/JXN/JXL3JXN/EFWeUNW+W80OwafBRwTdezRcVh9\n",
+       "mbuymT8NyqJYkiRJQ5FVngrsRbOd+gdRxyeijo26jUqSVuT2aUmSJA1d1LEZ8H7gScDrgW8621jS\n",
+       "FHuK+7AoliRJmgxRxyOAzwAXAK/OKv/ccUiSxoA9xZpY9naUzfyVzfyVy9yVzfzNLav8DbA78DPg\n",
+       "d1HHO6KOdTsOCzB3pTN/GpRFsSRJkkYqq7w1q/wQsAfwEOD4qC1oJHXD7dOSJEnqVNTx98AngF8C\n",
+       "b8oqL+04JEkj5vZpSZIkLVpZ5feBnYFLgJOjjn+OOvw9VdJI+D8bDZW9HWUzf2Uzf+Uyd2Uzf4PJ\n",
+       "Kq/LKt8M/C3wYuDXUceuo4zB3JXN/GlQFsWSJEkaG1nlicAjgS8BR0YdH446Nug4LEkTzJ5iSZIk\n",
+       "jaWoY3PgQ8BewGvabdaSJpBzivuwKJYkSVq8oo7HAgcCZwD/klWe23FIkhbYWBbFEfEMIIFegWVm\n",
+       "fmeYgc2IxaK4UBGxV2Ye1XUcGoz5K5v5K5e5K5v5G452lvGbgNcDHwQ+llXeuqCvYe6KZv7K1mXN\n",
+       "t9Yczz2FpiiezciKYkmSJC1uWeXNwHujjsOATwH/GHXsl1X+uuPQJBXO7dOSJEkqStQRwDOBjwE/\n",
+       "Av41q7yi26gkrY6x3D4NEBE7Af8M7NQ+dCrw+cw8fQSxTY/DoliSJEkriDo2BN4DPAd4K3BwVgWs\n",
+       "+EhaSZc136wjmSJiT+AXwLXA54DPAzcAR7XPSX05L65s5q9s5q9c5q5s5m90ssq/ZpWvBfYBXg0c\n",
+       "FXXcb9CvZ+7KZv40qLnmFFfAczOzyszvZeZ3M/NdwL7Au0YTniRJkjS3rPIPwMOAbwC/jDreF3Ws\n",
+       "13FYkgox19Wnz8jMHWZ57vTM3HGoka34em6fliRJUl9RxxbAR4GHAvtnlT/sOCRJ8zCWPcUR8cfM\n",
+       "3H2W547LzAcONbIVX8+iWJIkSfMWdTwB+DRwPPC6rPL8jkOSNIex7CkGto6IT0TEJ2fegC1HFaDK\n",
+       "Zm9H2czldLmUAAAgAElEQVRf2cxfucxd2czfeMgqfwLsApwCHBd1vC7qmGscqbkrnPnToOb6H8Ob\n",
+       "WXlO8VTl/vvhhCNJkiQtjKzyRqCKOg6hWTV+UdTxiqzy2I5DkzRGVnlOcUTcFXhKZn5jOCH1fE23\n",
+       "T0uSJGlg7Wzj5wEfBr4LvD2rvLrbqCRNGdft03eKiDUjYp+I+CpwDs0sOEmSJKkIWWVmlV8D7kez\n",
+       "+/HUqON5bbEsaRGba05xRMReEfFZmkL4JcDjgXtn5jNGFJ8KZ29H2cxf2cxfucxd2czfeMsqr8oq\n",
+       "9wP+AXgLcGTUsQOYu9KZPw1qrpXi84C3A78AdsrMZwI3ZOYNI4lMkiRJGpKs8hjgQcAPgKOjjgNY\n",
+       "j3U6DktSB+YayfRx4KnACcDXgcOBkzPz3qML785Y7CmWJEnSUEQdWwMfB/YETgcuAS5ub5fM+HhZ\n",
+       "VnlrR6FKE2ss5xQDRMQawF7Ac4G/AzYGXgb8IDOvG0WAbRwWxZIkSRqqdhv1VsA9gXvM+Dh1fwlw\n",
+       "Nb0L5pmPXZ5V3j7adyGVaWyL4hVOjFgH2JumQN47MzcbZmAzXtuiuFARsVdmHtV1HBqM+Sub+SuX\n",
+       "uSub+SvXfHIXdawJbMaKhfJsRfTGwBXMvuo8/f5VWeUdC/6mFhF/9srWZc035wDz6TLzFpot1IdH\n",
+       "xHrDC0mSJEkaT+3K76Xt7cS5zo061gbuzsqrzdsAD2bFInqDqONS5t66PXX/mqxWca6qpFmt8pzi\n",
+       "LrhSLEmSpEkWdawLbE7vLdszP65L/63bUx+vs4BWCYrYPt0li2JJkiSpEXWsR1Mcz7V1e+o+zF4w\n",
+       "Ty+mL8nKKTPqjkVxHxbF5bK3o2zmr2zmr1zmrmzmr1yTmLuoYwP6rz5P3b+FuVedp567NKu8eaRv\n",
+       "ZB4mMX+LyVj2FEfE2jRXmn4asGX78AXA94AvZHopekmSJGmcZZXXAWe1t1lFHQFsRO+Cec8Zj20e\n",
+       "dVxH/63bjrBSEeaaU3wYcBVwME0xDM0l6l8EbJKZzxlJhLhSLEmSJI2LqGMNYBP6b912hJXmbSy3\n",
+       "T0fEmZm5/ao+NwwWxZIkSVJ55jHCavr9jYHL6d//fDFwpRcQmyzjWhT/DvgI8K3MZmZaRKwBPAt4\n",
+       "Q2Y+dGRBWhQXy96Ospm/spm/cpm7spm/cpm7bs0xwqpXEb0BzVis5YXyH1mX3TkWR1gVaSx7ioF9\n",
+       "gQ8An4qIq9vHNgZ+0T4nSZIkSQui7T2+sL3NqecIq9vZE9geeBQrFtHrRB3zGWF1cduDrUWm79Wn\n",
+       "IyKATdvDK7ODy1W7UixJkiRpEHOMsOq1Eg3z63++OKu8cXTvYvKN5fZpgIjYCPg7mqtPJ80Ft36c\n",
+       "mVfP+klDYFEsSZIkadimjbDqVTCvygir6ffHcoTVuBnLojgiXghUwJHA+e3DWwOPB+rMPHgkEWJR\n",
+       "XDJ7c8pm/spm/spl7spm/spl7so2yvz1GGE1VxG9OTDfEVaXZpW3jeI9jJtx7Sl+B7DHzFXhiNgE\n",
+       "OJZmVJMkSZIkLSrthbuubm+nz3XuLCOspu7flxkjrKKOmSOsZiuiHWG1QOZaKT4DeEiPonhj4H8d\n",
+       "ySRJkiRJC6cdYbWE/lu3J26E1bhun34R8C7gJ6y4ffoJwHsy80sjiRCLYkmSJEmabtoIq/n0P688\n",
+       "wmr2IrqTEVZjWRQDRMSmwN7A0vahqQttXTWC2KbHYVFcKHtzymb+ymb+ymXuymb+ymXuymb+Zjdj\n",
+       "hFW/Inod5nH1bRZ4hNW49hSTmVcCh44oFkmSJEnSAmuvfn1ee5vTHCOs7g/8zfTHog6YgBFWfecU\n",
+       "9/ykiJMyc5chxDPb67lSLEmSJEljor0C9wbMr/+5/wirAzh87FaKI+IZPR5OIIAthhaRJEmSJGms\n",
+       "tX3H17a3s+Y6t88Iqz3bj52Z60JbtwKHAHfMfAp4ZmZuMOTYpsfiSnGh7O0om/krm/krl7krm/kr\n",
+       "l7krm/kr27j2FJ8EfDgzT5r5RET8zfBCkiRJkiRpNOZaKX40cG5mntvjuQdn5v8OO7hpr+dKsSRJ\n",
+       "kiRNqLEdyTQuLIolSZIkaXJ1WfOt0cWLavGIiL26jkGDM39lM3/lMndlM3/lMndlM38alEWxJEmS\n",
+       "JGnRmnP7dESsQXOl6W+MLqSecbh9WpIkSZIm1Nhun87MO4B/HVEskiRJkiSN1Hy2Tx8ZEW+KiK0j\n",
+       "YtOp23y+eER8MSIuiYiVxjrNOO/BEXFbRPzDvKJWMeztKJv5K5v5K5e5K5v5K5e5K5v506DmmlM8\n",
+       "ZV8ggVfPePze8/jcLwGfBL482wkRsSbwAeBHgFukJUmSJEkjM/SRTBGxDDg8M3eZ5fnXAbcADwaO\n",
+       "yMxv9zjHnmJJkiRJmlBj21MMEBHrR8Q7I+Lz7fH2EfHkhXjxiNgS+HvgwPah8R+aLEmSJEmaGPPp\n",
+       "Kf4SzUruw9vjC4H3LtDrfxx4azbL1YHbpyeOvR1lM39lM3/lMndlM3/lMndlM38a1Hx6irfLzGdH\n",
+       "xL4AmXl9xILVrnsAh7VfbwnwdxFxa2b+18wTI+Ig4Jz28Grg+Mw8qn1urzY2jz322GOPPS7+eMq4\n",
+       "xOOx+VtEx7sB4xSPx+Zvko93AzamsYwO9e0pjoijgb8Bjs7MB0bEdsChmfmQeb1An57iaed9qT3v\n",
+       "Oz2ey7SnWJIkSZImUpc133xWig+guTL0VhFxCPAI4MXz+eIRcSjwGGBJRJwHVMDaAJn52QHilSRJ\n",
+       "kiRpwczr6tMRsQR4KBDAMZl5+bADm/H6rhQXKiL2mtomofKYv7KZv3KZu7KZv3KZu7KZv7KN9Upx\n",
+       "RATNau8jgaRZ6f3ukOOSJEmSJGno5tNTfCCwHXAozUrxs4GzM/NVww/vzhhcKZYkSZKkCdVlzTef\n",
+       "ovhPwP0y8472eA3g1MzcaQTxTcVgUSxJkiRJE6rLmm8+c4rPAraZdrxN+5jU18zxFCqL+Sub+SuX\n",
+       "uSub+SuXuSub+dOg5nP16Q2B0yLiWJqe4ocA/xsRhwOZmU8dZoCSJEmSJA3LfLZP79Xj4aTpL87M\n",
+       "/OUQ4poZQ0IuBS7OpP/lsiVJkiRJxRjrnuJx0BbFlwPrAmcAp7e3qftnZHJ9hyFKkiRJkgY07j3F\n",
+       "YyGTuwPLgP2Bn9AUyM8EvgxcHsH5Efwsgk9H8LoI/i6CbSNYs7uoZW9H2cxf2cxfucxd2cxfucxd\n",
+       "2cyfBjWfnuKxkcmVwDHt7U5t4bs1sCOwQ/txn/b+5hGczYory1Ory5ePLnpJkiRJ0rhZpe3TEbEp\n",
+       "sFVmnji8kHq+7sBL6RGsB2zP8mJ5euF8Oz2KZeCsTG5agNAlSZIkSX2MdU9xRPwSeArNqvIfgMuA\n",
+       "32Tm64cf3p0xLPh/oAgC2JzexfIy4CJW7l0+HbggkzsWMhZJkiRJWszGvSg+PjN3i4h/ArbOzCoi\n",
+       "TsrMXUYT4uj/A0WwNk1hPLNY3pFmRNWZ9N6Ofc2oYixFROyVmUd1HYcGY/7KZv7KZe7KZv7KZe7K\n",
+       "Zv7K1mVRPJ+e4jUjYgvg2cA72sfG/5LVqyGTW2kK3zOBI6Y/F8GGLC+SdwCeDLwB2CGC6+i9Hfvs\n",
+       "9mtKkiRJksbIfFaKnwW8k2bL9H4RsR3wwcx8xigCbGPo7K8G89Vux96S3tuxtwTOpfc4qUucvSxJ\n",
+       "kiRpMRvr7dPjoISieC4RrAtsR+/t2GvTu1g+09nLkiRJkhaDsS6KI2JH4NPAPTNz54h4APDUzPz/\n",
+       "RhFgG0PRRfFcItiMFbdjTxXL2wGX03s79rmZ3N5JwKvI3o6ymb+ymb9ymbuymb9ymbuymb+yjXtP\n",
+       "8eeBNwOfaY9PAg4FRlYUT7JMrgB+297u1M5e3oYVi+WntPfvHsGf6bHC3H49SZIkSdI8zGel+PeZ\n",
+       "+aCIOC4zH9g+dnxm7jaSCJnsleJBRLA+s89evpXe27HPyuTmTgKWJEmSpDmM+0rxZRFxn6mDiHgm\n",
+       "zQxfdaTtNT6+vd2pvdjXPVhxO/aL2/v3iuBCem/HPt+LfUmSJElajOazUrwd8Dng4cBVwF+A52fm\n",
+       "OUOPbnkMrhSvpnb28r1ZuXd5B+BuNOOnem3H/uvqva69HSUzf2Uzf+Uyd2Uzf+Uyd2Uzf2Ub65Xi\n",
+       "zPwz8DcRsT6wRmZeO/ywtNDaOclntLcVRLARTXE8VSw/deo4gr/Sezv2X5y9LEmSJKl081kpvgvw\n",
+       "DGAZsCYQQGbmu4ce3fIYXCnuQARrMPvs5aU0s5dnFsunA5e6HVuSJEnSfI37SKYfA1cDf4DlY4Ay\n",
+       "8yPDDW2FGCyKx0wEd2H22ctr0bt3+YxMbugkYEmSJElja9yL4pMz8/4jime2GCyKC9LOXm4L5S88\n",
+       "Hl521+Y+2wGX0Xs79v+VMnt5MbE3p2zmr1zmrmzmr1zmrmzmr2xj3VMMHB0RD8jME4cejSZCOyv5\n",
+       "aODoiH86J/NlR8Gds5fvxfJV5Z1o+pd3BJa0s5dX2o6dyZUjfxOSJEmSFoVZV4oj4qT27po0M3H/\n",
+       "AnfOuc3MfMDww7szFleKJ9y02cu9tmPfQu/t2M5eliRJkibAWG6fjohls3xOtp93znBC6hmLRfEi\n",
+       "NW32cq9ieRvgAnpvx77Ai31JkiRJZRjLovjOE5o5xRdk5k0R8VhgF+DLmXn1KAJsY7AoLtQwezva\n",
+       "2cvb0nv28gY0s5dnFstnrO7s5cXE3pyymb9ymbuymb9ymbuymb+yjXtP8XeAPSLiPsBnge8DhwBP\n",
+       "GmZgUj/tnOSponcFEWzMyrOXdwS2b2cv9xoldY6zlyVJkqTFZT4rxcdl5gMj4i3AjZn5yanHRhOi\n",
+       "K8VaONNmL/fajr0FcA69t2M7e1mSJEkaknFfKb4lIp4HvBB4SvvY2sMLSRqeTO4AzmtvP53+XDt7\n",
+       "+T4sL5YfCbysPV4jomexfKazlyVJkqRyzWeleGfglcDRmXloRGwLPDsz3z+KANsYXCku1KT0dkSw\n",
+       "hN69y9sBl9J7O/Z5pc9enpT8LVbmr1zmrmzmr1zmrmzmr2xjvVKcmacA/zLt+GxgZAWxNA4yuRy4\n",
+       "HPjN9Mfb2cvLWF4s3xf4+/b+ZhGcxYwLfeHsZUmSJGlszGeleAfgfcD9gLu2D2dmbjvk2KbH4Eqx\n",
+       "ihPBBsw+e/kmevcu/9nZy5IkSVpsxn0k02+ACvgoTU/xS4A1M/Odww/vzhgsijUx2tnL96T3dux7\n",
+       "AefTezv2hV7sS5IkSZNo3IviP2bm7hFxUmbuMv2xkUSIRXHJ7O1YNRGsQzN7eWaxvCOwPjO2YbN8\n",
+       "9vK1w4nH/JXM/JXL3JXN/JXL3JXN/JVtrHuKgZsiYk3grIjYH7iQ5pdzSQssk1uAP7W3FUybvTxV\n",
+       "LD+N5bOXr6ZH7zLwl0xuG030kiRJUnnms1L8YJpf0DcG3gNsCHwwM48Zfnh3xuBKsTSLdvbyVvTu\n",
+       "Xb4nzezlXtuxL3M7tiRJksbB2G6fbleIP5CZbxpdSD3jsCiWBhDBXVlx9vL0j0Hv7dhnOXtZkiRJ\n",
+       "ozS2RTFARBwD7Jn9Thwii+Jy2dsxntqLfS2hd+/ytsAlwOnw1ZvgBX+gaZu4ELio/XhZ6TOYFwN/\n",
+       "/spl7spm/spl7spm/so27j3FxwPfj4hvwp2rR5mZ3xleWJKGqd02fVl7mzl7eS2aq2DvCJc+nub/\n",
+       "Ew8Dlk67bRzBJaxYKE+/TT12eSZ3jOI9SZIkSYOYz0rxQbBy32FmvmRIMfWKwZViaYy0V8m+JysW\n",
+       "ylv0ON4QuJj+xfMV9jdLkiQtXmO9fXocWBRLZYrgLqxYPM8snKceW5/lBfLM4nn68VUWz5IkSZNn\n",
+       "rIviiDgYeG1mXt0ebwJ8JDNfOoL4pmKwKC6UvR1lG1X+2guCTS+YZyue70L/VecLgWssnv35K5m5\n",
+       "K5v5K5e5K5v5K9u49xTvOlUQA2TmVRGx+xBjkrTIZHIjcHZ7m1UE69O7eH7AjMfWiphX8XytxbMk\n",
+       "SdLiNp+V4hOAx2bmle3xpsAvM3OXEcQ3FYMrxZLmLYK7sbxgnm3VeUua6yX0KpZXeCyT60b8FiRJ\n",
+       "khaVcV8p/gjw24j4Bs1c02cB7x1qVJK0GjK5FriWZv5yT+1Yqrux8qrzVsBDpj8WwW3MY9u2850l\n",
+       "SZLKM68LbUXEzsDjaFZVfp6Zpw47sBmv70pxoeztKJv5u7N43oj+/c5LgZvoXzxf1G4XH0Hs5q9U\n",
+       "5q5s5q9c5q5s5q9s475STGaeApwy5Fgkaey0PcdXt7dZ/yDYFs+bsHKhfB/g0dOOt4jgeuZXPN88\n",
+       "nHclSZKkKY5kkqQRaovnzei/6nxP4K/0L54vzuSW0b4LSZKkhTXWI5nGgUWxpMUmgjWAJfQvnu8B\n",
+       "XEX/4vmSTG4d7buQJEmaH4viPiyKy2VvR9nM3/iLYE3g7vQsnL99f3jGuu3x3YEr6F88X5rJbaN+\n",
+       "H1qRP3tlM3/lMndlM39lG/ueYknSeMrkduDi9nbc9OcinnnnLwcRrAVszsrF84NmPLZZBJfRv3i+\n",
+       "rH1tSZKkorlSLEm6UwRr02zJnmvL9lJgY+BS+hfPl2dyx2jfhSRJKo3bp/uwKJak8RLBOjQXA5tZ\n",
+       "PM883pBmFbtf8XxFe6VvSZK0CFkU92FRXC57O8pm/so2DvmLYF2a4nmuVeelwPpMG0fF7MXzVYuh\n",
+       "eB6H3Glw5q9c5q5s5q9s9hRLkiZSO2v53PY2qwjuSu/i+b4zju8SsVKh3Kt4vmYxFM+SJGn1DXWl\n",
+       "OCK+COwDXJqZu/R4/vnAW4AArgX2y8wTe5znSrEkiQjWo3+/81KaP/rOp3i+1uJZkqTuTez26Yh4\n",
+       "FHAd8OVZiuI9gVMz85qIeCJwQGY+rMd5FsWSpHmLYAP69zsvbU/vWzxnct0o45ckabGZ2KIYICKW\n",
+       "AYf3KopnnLcJcFJmbtXjOYviQtnbUTbzVzbz118Ed6P/qvNS4DbmVzzfsDBxmbuSmb9ymbuymb+y\n",
+       "2VPceBnww66DkCQtHplcC5ze3nqKIGiuoj2zUL4XsOf0xyK4if7F80WZ3DiktyRJklbRWKwUR8Rj\n",
+       "gU8Bj8jMq3o870qxJGmstcXzxvRfed4CuJ7Zi+eLgDMzuWzEb0GSpM4s6pXiiHgA8Hngib0K4mnn\n",
+       "HQSc0x5eDRw/tT0iIvYC8Nhjjz322OOujjPJiNi1PT5y9vPXAG4/CVgKb3oiLNkM3notsCN861mw\n",
+       "7hJ4ytIIfgfv/T18/teZ5/x31+/PY4899thjjxf4eDeaPyYDLKNDna4UR8Q2wM+BF2TmMXN8jUxX\n",
+       "iosUYW9Hycxf2cxfuSK23Bsu2AR4AfBI4AjgK8DPMrmt0+DUlz975TJ3ZTN/Zeuy5ltjmF88Ig4F\n",
+       "jgZ2jIjzIuKlEfGKiHhFe8q7gE2AAyPiuIg4dpjxSJJUhgtvzuSwTJ4M7AD8Dng3cF4EH4tgj3a7\n",
+       "tiRJWk1DXyleCK4US5IEEewAPJ9mBflm4KvAIZl3thdJklSkLms+i2JJkgrTrhLvSVMcPxs4lWZ7\n",
+       "9bcymfX6HJIkjauJ3T4tTTXVq0zmr2zmr1z9cpdJZnJ0Jq+iuaL1R4AnAOdE8O0Inh7BuiMIVT34\n",
+       "s1cuc1c286dBWRRLklSwTG7J5PuZPItmdvIPgdcAF0TwmQgeaf+xJEmzc/u0JEkTKIJtgOcB/wis\n",
+       "R9N//LVM/tRpYJIk9WBPcR8WxZIkDaZdJd6Npv/4ecD5NAXyYZlc0mVskiRNsadYE8vejrKZv7KZ\n",
+       "v3ItZO7a/uPjMnkjsBXwdmAP4PQIfhjB8yJYb6FeT/7slczclc38aVAWxZIkLRKZ3J7JkZm8ENiS\n",
+       "ZsX4BTT9xwdH8PgI1uw2SkmSRsvt05IkLXIR3APYl6ZA3hI4lGbE0wmZjP8vCpKk4tlT3IdFsSRJ\n",
+       "oxHBTjTF8QuA62hWkw/J5P86DUySNNHsKdbEsrejbOavbOavXF3mLpM/ZfIOYFvglcC9geMi+EUE\n",
+       "L4tg465iK4U/e+Uyd2UzfxqURbEkSVpJJndk8utMXgEsBT4BPAk4N4JvRPDUCNbpNkpJklaf26cl\n",
+       "SdK8RbAJ8Cya7dX3Bb5J0398jP3HkqRB2VPch0WxJEnjJ4JlwPOBfwTWpuk//momZ3YZlySpPPYU\n",
+       "a2LZ21E281c281euUnKXyTmZvJdmxfjZwIbAryI4JoL9I7h7txF2o5T8aWXmrmzmT4OyKJYkSasl\n",
+       "k8zkD5m8HtgKOAB4GHBmBEdE8JwI1us0SEmSZuH2aUmSNBQRbAA8jWZ79UOA79FssT4qk9u7jE2S\n",
+       "NF7sKe7DoliSpLJFsAWwL02BvDlwCE3/8YmdBiZJGgv2FGti2dtRNvNXNvNXrknMXSYXZfKxTHYH\n",
+       "9gZuAw6P4MQI3hzBVh2HuGAmMX+Lhbkrm/nToCyKJUnSSGVySiZvB+4N/AuwA3BiBD+L4CURbNht\n",
+       "hJKkxcTt05IkqXMR3AXYh2Z79WOB/6bpP/5xJrd2GZskafjsKe7DoliSpMUjgs2AZ9EUyNsDX6cp\n",
+       "kI/NZPx/cZEkrTJ7ijWx7O0om/krm/kr12LPXSZXZPKZTB5BM9rpUuDLwOkRvCuC7bqNcG6LPX8l\n",
+       "M3dlM38alEWxJEkaW5mcncl7gJ2A5wNLgN9GcHQEr4pgSbcRSpJK5/ZpSZJUlAjWBh4PvAB4EvBL\n",
+       "mu3VR2RyY5exSZIGY09xHxbFkiSpl/ZK1U+nKZD3AL5DUyD/TyZ3dBmbJGn+7CnWxLK3o2zmr2zm\n",
+       "r1zmbv4y+WsmB2fyeGAX4E/Ax4FzInh/BDuPOibzVy5zVzbzp0FZFEuSpImQyQWZfDiT3WjGOwH8\n",
+       "KILjInhjBEu7jE+SNJ7cPi1JkiZWBGsAj6HZXv104Pc026u/m8m1XcYmSVrOnuI+LIolSdLqiuCu\n",
+       "wFNoCuRHAz8EvgIcmcltXcYmSYudPcWaWPZ2lM38lc38lcvcDUcmN2byjUyeCtwH+A3wLuCCCP49\n",
+       "ggdHsNq/kJm/cpm7spk/DcqiWJIkLTqZXJ7JpzLZE3gEcCVwKHBaBO+I4N7dRihJGhW3T0uSJAHt\n",
+       "KvFDabZXPwc4nWZ79TczubLL2CRp0tlT3IdFsSRJGqUI1gb2Bv4ReCLwc5oC+QeZ3NxlbJI0iewp\n",
+       "1sSyt6Ns5q9s5q9c5q57mdyayRGZPAfYBvgvYH/gwgg+F8Gj2ytbr8T8lcvclc38aVAWxZIkSXPI\n",
+       "5JpMvpTJ44DdgLOATwFnR/DeCO7bbYSSpNXh9mlJkqQBRLArTf/x84CLaeYfH5rJxZ0GJkkFsqe4\n",
+       "D4tiSZI0riJYE9iLpv/474Hf0RTI38vkug5Dk6Ri2FOsiWVvR9nMX9nMX7nMXVkyuT2Tn2XyYmBL\n",
+       "ePexwL7A+RF8JYK9I1ir2yg1H/7slc38aVAWxZIkSQskkxug+nkmTwZ2AI4F3g2cF8FHI9i9Hf0k\n",
+       "SRoTbp+WJEkasgh2oOk/fgFwE8326q9lcm6ngUnSmLCnuA+LYkmSNAnaVeI9aYrjZwOn0BTI38rk\n",
+       "qi5jk6Qu2VOsiWVvR9nMX9nMX7nMXdnmyl8mmcnRmbwKWAp8FHgCcE4E34rgaRGsO6JQNYM/e2Uz\n",
+       "fxqURbEkSVIHMrklk+9n8izgXsCPgNcBF0TwmQgeYf+xJA2f26cl6f9v796D5qrLA45/H0OohAAR\n",
+       "cLglGmhpG1okoFy8QFMVSaEQbiOCQrCtolNKO0KhIq3MVGzrYEsFyVAHgeE6KAwFud9BHRluwYBc\n",
+       "KyDXQLkmIPenf5zzluUlyb7Zd/c9+9v9fmbOZM/Zs3ue3Se/5H3e83vOkaQ+EsEHqO59vD+wGnAm\n",
+       "cEYm9zYamCT1kD3FbVgUS5KkYVOfJZ5N1X+8H/AocDpwTiZPNRmbJHWbPcUaWPZ2lM38lc38lcvc\n",
+       "la1b+av7j2/P5FBgBvAN4CPAfRFcEsG+EUzpxrFUceyVzfypUxbFkiRJfS6TNzK5IpMDgI2oplQf\n",
+       "QNV/fFoEO0YwqdkoJalMTp+WJEkqVATrA/tQTbHeCDiL6hZPd2TS/z/kSVLNnuI2LIolSZJWLIJZ\n",
+       "wOepCuSlVP3HZ2XySKOBSdIY2FOsgWVvR9nMX9nMX7nMXdmayl8md2dyFLAJ8NX6z4URXBvBX0aw\n",
+       "VhNxlcSxVzbzp05ZFEuSJA2QTN7K5MZMDgI2BL4H7Az8JoJzI9gtglWbjVKS+ofTpyVJkoZABGsD\n",
+       "e1NNr54FnEvVf/wL+48lNc2e4jYsiiVJkrongo2p7n28P7AKVXF8Zib3NxqYpKFlT7EGlr0dZTN/\n",
+       "ZTN/5TJ3ZSshf5k8mMkxVGeM9wGmATdG8IsIDo7g/c1G2IwScqflM3/qlEWxJEnSkMokM7k1k78D\n",
+       "pgNHA9sB90dwUQT7RLBao0FKUo85fVqSJEnvEMEawO5U/cfbABdQ3eLp+kzebDI2SYNpYKdPR8QP\n",
+       "I2JxRCxawT7fi4j7I+KOiNiyl/FIkiSpvUyWZHJ6JjsBmwGLgGOBhyP4TgSbNxuhJHVPr6dPnwLM\n",
+       "Xd6TEbEz8HuZuSnwZWBBj+PRBLO3o2zmr2zmr1zmrmyDlr9Mnsjk3zPZCtgJeBO4OII7Ivj7CKY3\n",
+       "HGLXDFruho35U6d6WhRn5o3AcyvYZTfgtHrfm4BpEbFeL2OSJElSZzK5K5OvAzOBQ4DfB34ZwdUR\n",
+       "HBjBmo0GKEkdaPpCWxsBj7SsPwqD89tGQWZe13QM6pz5K5v5K5e5K9sw5C+TtzK5PpMvARtSzfbb\n",
+       "HXgkgnMi2CWCyc1GufKGIXeDzPypU00XxQCjm6n7/8pfkiRJAiCTVzL5cSa7A5sA1wNHAo9FcHwE\n",
+       "20a86+c9SeobqzR8/MeAGS3r0+tt7xIRpwIP1avPAwtHfhs00j/gev+tt/Z29EM8rpu/YVo3f+Wu\n",
+       "j2zrl3hcN38rub4AWBCxy36w66fgK6dXz5/0U7jwqsyLz+qzeFvXZ2fmcX0Uj+vmb5DXZ1PdIx2q\n",
+       "lozG9PyWTBExE7goM991lcKoLrR1cGbuHBHbAcdl5nbL2C/TWzIVKSLmjPzlV3nMX9nMX7nMXdnM\n",
+       "3wUOUCYAAA3ySURBVDvVZ4m3prq90+eAB6hu73RuJs80Gdto5q5s5q9sTdZ8PS2KI+Js4E+AdYHF\n",
+       "wDeh6i/JzJPqfU6gukL1S8AXM/O2ZbyPRbEkSVLh6j7jHYH9gZ2B64AzgIsyeaXB0CQ1bGCL4m6x\n",
+       "KJYkSRos9ZWq96AqkLcCzqcqkG/I5K0mY5M08Zqs+frhQlsaYK39VSqP+Sub+SuXuSub+RubTF7M\n",
+       "5LRMPg1sDtwDHAc8FMG/RPBHEx2TuSub+VOnLIolSZLUqEwey+TYTGYDu1D9jHp5BLdHcGgEGzQc\n",
+       "oqQB5vRpSZIk9Z0IJgE7UE2v3gO4mWp69fmZLG0yNkndZ09xGxbFkiRJwyuC1YBdqa5gvQNwMVWB\n",
+       "fGUmbzQZm6TusKdYA8vejrKZv7KZv3KZu7KZv+7L5LeZnJvJbsCmwM+BfwIei+A/I/hIfeuncTF3\n",
+       "ZTN/6pRFsSRJkoqRydOZfD+TjwIfB54DzgHujuCoCDZuNkJJpXH6tCRJkopWnyXelqr/+LNUV7I+\n",
+       "A/hRJs82GZuksbGnuA2LYkmSJI1FBKsCO1H1H+8EXENVIF+cyatNxiZp+ewp1sCyt6Ns5q9s5q9c\n",
+       "5q5s5q9ZmbyWyUWZ7AN8EPgJcDDweAT/FcH2Ecv+Gdjclc38qVMWxZIkSRpImbyQyQ8z+SQwG3gA\n",
+       "OBH4dQTHRDCr2Qgl9QOnT0uSJGlo1P3HH6KaXr0f8ATV9OpzMnmyydikYWZPcRsWxZIkSeq2CCYB\n",
+       "f0pVIM8DfgksBpYCL9V/ti6jt71jPZPXJ/gjSAPDorgNi+JyRcSczLyu6TjUGfNXNvNXLnNXNvNX\n",
+       "pgimwGF/Dcf+BlgdmNqyjF5f3rY3aVM4L2O93T4vZfJmbz/9YHDsla3Jmm+VJg4qSZIk9ZNMXo74\n",
+       "7s2Zx17XyevradmrsuLCuXX9fcB02hfbUyJ4le4X2y9n0v9nx6QJ4JliSZIkqU/VxfZqjL3YHus+\n",
+       "76UqkrtdbL9qsa1OOH26DYtiSZIkqXvqfuopjL+4Hr1tEmMrrleq2LZfe/BZFLdhUVwuezvKZv7K\n",
+       "Zv7KZe7KZv7KZe7GL4LJdOdM9uhtb9K2uD51Ghx4L2Mvtu3X7iP2FEuSJEkqXn1G9/l66Yp6Cvnv\n",
+       "0LZwfnEL4FWqfu0Zy97nHeurR/AK3Zk23rpuv3ZhPFMsSZIkaehE8B7e7tdud+Z6Zc52j/Rrd3sa\n",
+       "+UD3azt9ug2LYkmSJEklqPu1//9sNN2bSj7Sr93VM9v90q9tUdyGRXG57M0pm/krm/krl7krm/kr\n",
+       "l7kr26DnL4JVWX6x3WkBPhV4g+4X2yvdr21PsSRJkiRpuTJ5DXgNeK5b79nSrz3WQnod4ANt9hm5\n",
+       "v/ZIv/ZYi+3GeKZYkiRJktQ1o/q1x3gmO77m9OkVsCiWJEmSpMHVZM33niYOquEREXOajkGdM39l\n",
+       "M3/lMndlM3/lMndlM3/qlEWxJEmSJGloOX1akiRJktQop09LkiRJktQAi2L1lL0dZTN/ZTN/5TJ3\n",
+       "ZTN/5TJ3ZTN/6pRFsSRJkiRpaNlTLEmSJElqlD3FkiRJkiQ1wKJYPWVvR9nMX9nMX7nMXdnMX7nM\n",
+       "XdnMnzplUSxJkiRJGlr2FEuSJEmSGmVPsSRJkiRJDbAoVk/Z21E281c281cuc1c281cuc1c286dO\n",
+       "WRRLkiRJkoaWPcWSJEmSpEbZUyxJkiRJUgMsitVT9naUzfyVzfyVy9yVzfyVy9yVzfypUxbFkiRJ\n",
+       "kqShZU+xJEmSJKlR9hRLkiRJktQAi2L1lL0dZTN/ZTN/5TJ3ZTN/5TJ3ZTN/6pRFsSRJkiRpaNlT\n",
+       "LEmSJElqlD3FkiRJkiQ1wKJYPWVvR9nMX9nMX7nMXdnMX7nMXdnMnzplUSxJkiRJGlr2FEuSJEmS\n",
+       "GmVPsSRJkiRJDbAoVk/Z21E281c281cuc1c281cuc1c286dOWRRLkiRJkoaWPcWSJEmSpEbZUyxJ\n",
+       "kiRJUgN6WhRHxNyIuCci7o+II5bx/LoRcVlELIyIOyPiwF7Go4lnb0fZzF/ZzF+5zF3ZzF+5zF3Z\n",
+       "zJ861bOiOCImAScAc4HNgH0jYtao3Q4Gbs/M2cAc4LsRsUqvYlIjZjcdgMbF/JXN/JXL3JXN/JXL\n",
+       "3JXN/KkjvTxTvA3wQGY+lJmvA+cA80bt8wSwZv14TeCZzHyjhzFp4k1rOgCNi/krm/krl7krm/kr\n",
+       "l7krm/lTR3p5VnYj4JGW9UeBbUft8wPgmoh4HFgD+GwP45EkSZIk6R16eaZ4LJe1PhJYmJkbUk13\n",
+       "+H5ErNHDmDTxZjYdgMZlZtMBaFxmNh2AOjaz6QA0LjObDkAdm9l0ABqXmU0HoDL17JZMEbEdcHRm\n",
+       "zq3Xvw68lZn/1rLPJcAxmfmzev1q4IjMvGXUe/X/faMkSZIkSR1r6pZMvZw+fQuwaUTMBB4H9gH2\n",
+       "HbXPPcCngZ9FxHrAHwC/Hv1G3qNYkiRJktQLPSuKM/ONiDgYuByYBJycmXdHxEH18ycB3wZOiYg7\n",
+       "qKZyH56Zz/YqJkmSJEmSWvVs+rQkSZIkSf1u3BfaiogZEXFtRNwVEXdGxCH19rUj4sqIuC8iroiI\n",
+       "aS3br42IJRFx/Kj3ui4i7omI2+tl3Xr7DhFxW0S8HhF7jXrN/PoY90XEAS3bz6zfa1FEnDxy/+OI\n",
+       "mBcRd9Tvf2tEfHK834HUhNLGXsvzW0fEGxGxZ6++G6nXSht/ETEnIl5oOcZRvf6OpF4obezVz82p\n",
+       "3//OiLiuh1+P1DOljb2IOKzl/RfVP3su/5ZdmTmuBVgfmF0/ngrcC8wCvkM1HRrgCOBf68dTgI8D\n",
+       "BwHHj3qva4GtlnGMDwKbA6cBe7VsXxv4H6p7kk0beVw/92ct+50FfKV+vHrL9s2p7qU87u/BxWWi\n",
+       "l9LGXr0+CbgG+Enr+7m4lLaUNv6AOcCFTX9vLi7jXQoce9OAu4Dp9fq6TX+HLi6dLKWNvVHv++fA\n",
+       "VSv6fOM+U5yZT2bmwvrxUuBuqnsU71Z/IOo/d6/3eTmrq02/upy3fNdFtTLz4cxcBLw16qmdgCsy\n",
+       "8/nMfB64Ephbv+bSlv1uBqbX219q2T4V+N8xflSpr5Q29mp/A/wYeHqsn1PqR4WOPy9aqeIVNPY2\n",
+       "qh/vB5yXmY/W+/lzp4pU0NibzrvtB5y9os/X1fsUR3Wl6S2Bm4D1MnNx/dRiYL1Ruy+vmfm0lZja\n",
+       "tSHwaMv6o7z9j9BITJOBLwCXtmzbPSLurrcdMobjSH2thLEXERsB84AFbeKQilLC+Kt9LKr2oUsi\n",
+       "YrMxHEfqa30+9i6rN20KjEwjvSUi9h/DcaS+1udj79JR26dQFdXnregAXSuKI2JqfbC/zcwlrc9l\n",
+       "dd56LD8Afz4z/xjYHti+S/9wnAhcX/+mYiSeCzJzFrArcHoXjiE1pqCxdxzwD3VMgWetNAAKGn+3\n",
+       "AjMycwvgeOCCLhxDakxBY28ysBWwM9UP5v8YEZt24ThSIwoaeyN2BX5an2Ferq4UxXVlfh5wemaO\n",
+       "/Ee7OCLWr5/fAHiq3ftk5uP1n0up5oRvs6zdWh4/BsxoWZ9By28RIuKbwDqZ+bXlHO9GYJWIWKdd\n",
+       "bFI/KmzsfRg4JyIeBPYCToyI3drFJvWrksZfZi7JzJfrx5cCkyNi7bYfUupDJY094BGqaZ+/zcxn\n",
+       "gBuALdrFJvWjwsbeiM/RZuo0dOfq0wGcDPwqM49reepCYH79eD7v/q30O84SRcSkliuPTaaq6hct\n",
+       "4zWtr7sc+ExETIuI9wE71tuIiL8CPkM1h7z1OL9bx0xEbAVQ/yMlFaW0sZeZm2Tmxpm5MVVf8Vcz\n",
+       "88KV+MhS3yht/EXEei3/921DdUvGZ8f+iaX+UNrYA/4b+ER9vCnAtsCvxvhxpb5R4NgjItYCdqAa\n",
+       "hyuWK7gK11gW4BNUzdALgdvrZS7VVcKuAu4DrqC+Qlj9moeAZ4AlVL9B+0OqK5TdAtwB3An8B2/f\n",
+       "R3nrer+lVBfGWtTyXl8E7q+X+S3bX6+3jcR0VL398Pr9bwduBLYe73fg4tLEUtrYGxX7KcCeTX+H\n",
+       "Li6dLqWNP+Dg+v0XAj8Htmv6O3Rx6WQpbezVzx1GdQXqRcAhTX+HLi6dLIWOvfnAWWP5fCMBSJIk\n",
+       "SZI0dLp69WlJkiRJkkpiUSxJkiRJGloWxZIkSZKkoWVRLEmSJEkaWhbFkiRJkqShZVEsSZIkSRpa\n",
+       "FsWSJDUgIo6OiENX8Py8iJg1kTFJkjSMLIolSWpGtnl+D2CziQhEkqRhFpnt/k+WJEndEBHfAA4A\n",
+       "ngIeAW4FXgC+DKwKPADsD2wJXFQ/9wKwJ9Uvsk8A3g+8DHwpM++d4I8gSdLAsSiWJGkCRMSHgVOA\n",
+       "bYDJwG3AAuDUzHy23uefgcWZeUJEnAJclJnn189dDRyUmQ9ExLbAtzPzU018FkmSBskqTQcgSdKQ\n",
+       "2B44PzNfAV6JiAuBADaPiG8BawFTgctaXhMAETEV+Cjwo4gYeW7ViQpckqRBZlEsSdLESOoid5RT\n",
+       "gHmZuSgi5gNzRr0GqqnTz2fmlr0NUZKk4eOFtiRJmhg3ALtHxHsjYg1g13r7GsCTETEZ+AJvF8JL\n",
+       "gDUBMvNF4MGI2BsgKh+a0OglSRpQ9hRLkjRBIuJIYD7VhbYepuorfhk4HHgauAmYmpl/EREfA34A\n",
+       "vALsTVUsLwA2oOpJPjszvzXhH0KSpAFjUSxJkiRJGlpOn5YkSZIkDS2LYkmSJEnS0LIoliRJkiQN\n",
+       "LYtiSZIkSdLQsiiWJEmSJA0ti2JJkiRJ0tCyKJYkSZIkDS2LYkmSJEnS0Po/vLXjT8snq9AAAAAA\n",
+       "SUVORK5CYII=\n"
+      ],
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f936c2eab90>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data = { \"e10s\": pd.Series(e10s_crash_rate_per_day),\n",
+    "         \"non-e10s\": pd.Series(non_e10s_crash_rate_per_day) }\n",
+    "df = pd.DataFrame(data)\n",
+    "df.plot()\n",
+    "plt.xlabel(\"date\")\n",
+    "plt.ylabel(\"crashes per %d ADI\" % PER_ADI)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Crashes per client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_crashes_per_client(crashes):\n",
+    "    return crashes.map(lambda p: (p[\"clientId\"], 0)).countByKey()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "e10s_crashes_per_client = get_crashes_per_client(e10s_crash_pings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "non_e10s_crashes_per_client = get_crashes_per_client(non_e10s_crash_pings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": [
+       "iVBORw0KGgoAAAANSUhEUgAAA7sAAAG3CAYAAAB1x0KkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\n",
+       "AAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xu85XVd7/H3G5D7ZQB15DK2KcTEFBTE+4GSiBTB8ihQ\n",
+       "lnlILewo0Q0qj56OkeipUJOOpjjEETxkRJqXGEitrLgpiAwXQSeYUQYDBgaMy8Dn/LF+m1ns2Xtm\n",
+       "75nfXuv9++3X8/GYB+u3rt/Na4bhs3/ru7arSgAAAAAA9MlW414AAAAAAABtY9gFAAAAAPQOwy4A\n",
+       "AAAAoHcYdgEAAAAAvcOwCwAAAADoHYZdAAAAAEDvzNuwa/sc26ttXzd03ftt32D7WtsX2d5t6LbT\n",
+       "bX/L9o22jxq6/hDb1zW3fWC+1gsAAAAA6I/5PLP7CUlHT7nuEknPrqqDJN0s6XRJsn2gpOMlHdg8\n",
+       "5mzbbh7z55JOqqpnSHqG7anPCQAAAADAE8zbsFtV/yTpninXLauqx5rDyyXt21w+TtIFVfVIVa2Q\n",
+       "dIukF9reS9IuVXVFc7+/lPSa+VozAAAAAKAfxrln979J+nxzeW9JK4duWylpn2muX9VcDwAAAADA\n",
+       "jMYy7Nr+PUkPV9X543h9AAAAAEC/bTPqF7T9S5JeKekVQ1evkrRk6HhfDc7ortL6tzpPXr9qhuet\n",
+       "VhcKAAAAAIhSVd70vQZGOuw2Hy71W5IOr6oHh276jKTzbf+JBm9TfoakK6qqbN9n+4WSrpD0C5I+\n",
+       "ONPzz+ULx/yx/e6qeve41wFaJKFFFnrkoEUOWuSgRQ5aZJnrCc55G3ZtXyDpcElPtn27pHdp8OnL\n",
+       "20pa1nzY8r9W1clVtdz2hZKWS1on6eSqmvxCTpa0VNIOkj5fVV+crzWjNRPjXgAeNzHuBeBxE+Ne\n",
+       "AJ5gYtwLwOMmxr0APG5i3AvA4ybGvQA8bmLcC8Dmm7dht6pOnObqczZy/zMknTHN9VdLek6LSwMA\n",
+       "AAAA9Nw4P40Z/bV03AvA45aOewF43NJxLwBPsHTcC8Djlo57AXjc0nEvAI9bOu4F4HFLx70AbD6v\n",
+       "f7dwt9ku9uwCAAAAQD/NdeYb+acxp7P9Im3838uVVfXQqNbTRbaPqKovj3sdoEUSWmShRw5a5KBF\n",
+       "DlqMDz/hJUcbJzIZdqd6mt6g52oXbaXHNrjtBm2lf9d1khh2AQAAgB4aHrL4xsN4tPVNB97GPPV5\n",
+       "9vaH9Ubdo+21boMbz9MS3apTq+reLX0dAAAAAFnYGplhpg5z7cMHVAEAAAAAeodhF62zfcS414AB\n",
+       "WuSgRRZ65KBFDlrkoEUOWnQbwy4AAAAAoHcYdtE6NvHnoEUOWmShRw5a5KBFDlrk6EoL2z9m++9t\n",
+       "f9/2Bh+0a3sP239j+37bK2yfOI51jhqfxgwAAAAAM7CXnCUtXjR/r7B6TdXtp2zhkzws6VOSPizp\n",
+       "4mlu/7CkByU9VdLzJH3O9rVVtXwLXzcawy5ax0e056BFDlpkoUcOWuSgRQ5a5Bjs2T1kkXTVivl7\n",
+       "lUMnZntP23tL+pCkl0u6X9KfVtWHqupmSTfb3n+ax+wk6WclPbuqfiDpq7b/VtIvSDrd9pMlLZX0\n",
+       "UkmPSbpe0uHVgx/bw7ALAAAAAOFsbyXps5L+RtLxkpZIutT2TVV1yUYeeoCkdVV1y9B110o6orn8\n",
+       "G5Jul/Tk5vhFfRh0JfbsYh7wncgctMhBiyz0yEGLHLTIQYscYS1eIOnJVfWeqlpXVd+R9DFJJ2zi\n",
+       "cTtLum/KdWsl7dJcfljSXpImqurRqvpqm4seJ4ZdAAAAAMj3Q5L2tn3P5C9Jp2uwD3dj7pe065Tr\n",
+       "dtNg4JWk90u6RdIltm+1/TttLnqcGHbROn4eWQ5a5KBFFnrkoEUOWuSgRY6wFrdJ+k5V7T70a9eq\n",
+       "OmYTj7tZ0jZT9vMeJOmbklRV91fVb1bVj0g6VtKptn9iXr6CEWPYBQAAAIB8V0haa/u3be9ge+vm\n",
+       "Rw4dKkm2t5e0bXN5O9vbSVJVPSDpIkl/YHtH2y+T9GpJ5zX3fZXt/W1bg7c7P9r86jyGXbQubG/D\n",
+       "gkaLHLTIQo8ctMhBixy0yJHUoqoek3SMpIMlfVvS9yV9VNKutick/UCDs7Ul6T8l3TD08JMl7SDp\n",
+       "Tkn/V9KvVNXk7c+QtEyDtzX/i6QPV9VX5vnLGQk+jRkAAAAAZrR6zVx+PNDmPf/sVNX3JP3cDDfP\n",
+       "eCKzqu6R9DMz3HaWpLNmu4YuYdhF6/jZcDlokYMWWeiRgxY5aJGDFjmaFqeMex3YPLyNGQAAAADQ\n",
+       "Owy7aB3ficxBixy0yEKPHLTIQYsctMhBi25j2AUAAAAA9A7DLloX9vPIFjRa5KBFFnrkoEUOWuSg\n",
+       "RQ5adBvDLgAAAACgdxh20Tr2NuSgRQ5aZKFHDlrkoEUOWuSgRbcx7AIAAAAAeodhF61jb0MOWuSg\n",
+       "RRZ65KBFDlrkoEUOWnQbwy4AAAAAYJNs/7jtL9leY/s709w+0dz+gO0bbL9iHOuctM04Xxz9xN6G\n",
+       "HLTIQYss9MhBixy0yEGLHFX1Ze/ms7STFs3bizygNXVvnTJvz9+u+yV9TNKOkn53mtsvkPRVSUdL\n",
+       "epWkT9t+RlX9x+iWuB7DLgAAAADMZCct0lu1Yt6e/yOamM3dbK+Q9CFJvyjphyR9UdIbq+oh22+W\n",
+       "9NuS9pD0z5J+paq+1zzuMUm/Kuk3JD1F0ier6tc28jo/2rzO8yV9X9I7q+qvJKmqrpR0pe0jp3nc\n",
+       "AZKeJ+nIqnpI0kW23yHptZI+Ynt/SR+XdJCkRyRdVlUnzOZr31y8jRmtY29DDlrkoEUWeuSgRQ5a\n",
+       "5KBFjrAWJel1kn5K0n6Snivpl2z/hKQzmtv2kvTvkj415bGvknRo85jX2/6p6V7A9k6Slkn6vxoM\n",
+       "xidIOtv2s2axvmdL+nZVPTB03bXN9ZL0vyR9saoWSdpH0gdn8ZxbhGEXAAAAALrhg1V1R1XdI+mz\n",
+       "kg6W9HOSPl5V11TVw5JOl/Ri208fetx7q+q+qrpd0peax03nGEnfqapzq+qxqrpG0kUaDNKbsrOk\n",
+       "e6dct7a5XpIeljRhe5+qeriq/mUWz7lFGHbROvaZ5KBFDlpkoUcOWuSgRQ5a5AhsccfQ5R9oMEju\n",
+       "Lem2ySubM6t3aXD2dKbH7SRJtq+3vdb2fbZfpsHbo19o+57JXxoM04tnsbb7Je065brdNBh4pcHb\n",
+       "rC3pCtvftP2mWTznFmHPLgAAAAB013c1GFIlPf5W5D0lrdrIYyxJVfXsJ1xp7yvpK1V11Gas43pJ\n",
+       "P2x756q6v7nuIEnnNa+1WtJbmtd5qaRLbX+lqr69Ga81K5zZRevC9jYsaLTIQYss9MhBixy0yEGL\n",
+       "HOEt3PzzAklvsn2Q7e002L/7b1V12yYeN52/k3SA7TfYflLz6wXNh1bJA9tLelJzuJ3tbSWpqm6W\n",
+       "dI2kd9ne3vbPSvoxSX/dPPZ1zTAtSWs02IP82OZ+8bPBsAsAAAAA3VOSqqouk/RODYbK72rw4VUn\n",
+       "TLnfBo+b9gkHZ2SPah6/StL3JP2RpG2buxyuwdugPydpiaT/1OBToSedoMEHYd0t6Q8lvbaq7mpu\n",
+       "O1TSv9leK+lvJb29qlbM6SueI1dN+3V2ju2qqo19l2J2z7O3P6w36h5tr3Ub3HieluhWnVpVUzde\n",
+       "AwAAAOi46WYKfs7u6M0028115mPPLgAAAADMgEG0u3gbM1oXvrdhQaFFDlpkoUcOWuSgRQ5a5KBF\n",
+       "tzHsAgAAAAB6h2EXrQv8eWQLFi1y0CILPXLQIgctctAiBy26jWEXAAAAANA7DLtoHXsbctAiBy2y\n",
+       "0CMHLXLQIgctctCi2xh2AQAAAAC9w48eQuvY25CDFjlokYUeOWiRgxY5aDFetmvK8biWgi3EsAsA\n",
+       "AAAAkqqKybZHeBszWsfehhy0yEGLLPTIQYsctMhBixy06DaGXQAAAABA7zDsonXsM8lBixy0yEKP\n",
+       "HLTIQYsctMhBi25j2AUAAAAA9A7DLlrH3oYctMhBiyz0yEGLHLTIQYsctOg2hl0AAAAAQO8w7KJ1\n",
+       "7G3IQYsctMhCjxy0yEGLHLTIQYtuY9gFAAAAAPQOwy5ax96GHLTIQYss9MhBixy0yEGLHLToNoZd\n",
+       "AAAAAEDvzNuwa/sc26ttXzd03R62l9m+2fYlthcN3Xa67W/ZvtH2UUPXH2L7uua2D8zXetEe9jbk\n",
+       "oEUOWmShRw5a5KBFDlrkoEW3zeeZ3U9IOnrKdadJWlZVB0i6rDmW7QMlHS/pwOYxZ9t285g/l3RS\n",
+       "VT1D0jNsT31OAAAAAACeYN6G3ar6J0n3TLn6WEnnNpfPlfSa5vJxki6oqkeqaoWkWyS90PZeknap\n",
+       "qiua+/3l0GMQir0NOWiRgxZZ6JGDFjlokYMWOWjRbaPes7u4qlY3l1dLWtxc3lvSyqH7rZS0zzTX\n",
+       "r2quBwAAAABgRmP7gKqqKkk1rtfH/GFvQw5a5KBFFnrkoEUOWuSgRQ5adNs2I3691bafVlV3NG9R\n",
+       "vrO5fpWkJUP321eDM7qrmsvD16+a6cltL5W0ojlcI+mayd+gk29B2NSx9moefZUmJEmHNs93lSa0\n",
+       "Vk8Zeq1ZPR/HHHPMMcccc8wxxxxzzDHHm3V8sKTJDzWe0By5av5OrtqekPTZqnpOc/w+SXdV1Zm2\n",
+       "T5O0qKpO8+ADqs6XdJgGb1O+VNL+VVW2L5f0dklXSPqcpA9W1Renea2qKk+9fs5r3tsf1ht1j7bX\n",
+       "ug1uPE9LdKtOrap7t/R1+sz2EZO/STFetMhBiyz0yEGLHLTIQYsctMgy15lv3s7s2r5A0uGSnmz7\n",
+       "dkn/Q9J7JV1o+yQNzsC+XpKqarntCyUtl7RO0sm1fgo/WdJSSTtI+vx0gy4AAAAAAMPm9czuKHFm\n",
+       "FwAAAAD6a64z39g+oAoAAAAAgPnCsIvWTW4ux/jRIgctstAjBy1y0CIHLXLQotsYdgEAAAAAvcOw\n",
+       "i9bxiXU5aJGDFlnokYMWOWiRgxY5aNFtDLsAAAAAgN5h2EXr2NuQgxY5aJGFHjlokYMWOWiRgxbd\n",
+       "xrALAAAAAOgdhl20jr0NOWiRgxZZ6JGDFjlokYMWOWjRbQy7AAAAAIDeYdhF69jbkIMWOWiRhR45\n",
+       "aJGDFjlokYMW3cawCwAAAADoHYZdtI69DTlokYMWWeiRgxY5aJGDFjlo0W0MuwAAAACA3mHYRevY\n",
+       "25CDFjlokYUeOWiRgxY5aJGDFt3GsAsAAAAA6B2GXbSOvQ05aJGDFlnokYMWOWiRgxY5aNFtDLsA\n",
+       "AAAAgN5h2EXr2NuQgxY5aJGFHjlokYMWOWiRgxbdxrALAAAAAOgdhl20jr0NOWiRgxZZ6JGDFjlo\n",
+       "kYMWOWjRbQy7AAAAAIDeYdhF69jbkIMWOWiRhR45aJGDFjlokYMW3cawCwAAAADoHYZdtI69DTlo\n",
+       "kYMWWeiRgxY5aJGDFjlo0W0MuwAAAACA3mHYRevY25CDFjlokYUeOWiRgxY5aJGDFt3GsAsAAAAA\n",
+       "6B2GXbSOvQ05aJGDFlnokYMWOWiRgxY5aNFtDLsAAAAAgN5h2EXr2NuQgxY5aJGFHjlokYMWOWiR\n",
+       "gxbdxrALAAAAAOgdhl20jr0NOWiRgxZZ6JGDFjlokYMWOWjRbQy7AAAAAIDeYdhF69jbkIMWOWiR\n",
+       "hR45aJGDFjlokYMW3cawCwAAAADoHYZdtI69DTlokYMWWeiRgxY5aJGDFjlo0W0MuwAAAACA3mHY\n",
+       "RevY25CDFjlokYUeOWiRgxY5aJGDFt3GsAsAAAAA6B2GXbSOvQ05aJGDFlnokYMWOWiRgxY5aNFt\n",
+       "DLsAAAAAgN5h2EXr2NuQgxY5aJGFHjlokYMWOWiRgxbdxrALAAAAAOgdhl20jr0NOWiRgxZZ6JGD\n",
+       "FjlokYMWOWjRbQy7AAAAAIDeYdhF69jbkIMWOWiRhR45aJGDFjlokYMW3cawCwAAAADoHYZdtI69\n",
+       "DTlokYMWWeiRgxY5aJGDFjlo0W0MuwAAAACA3mHYRevY25CDFjlokYUeOWiRgxY5aJGDFt22zbgX\n",
+       "MA6295rxxsXaUaV7RrgcAAAAAEDLXFXjXkMrbFdVeXb3PeDD0sHbTXvj7l94kU66/7PaWQ9tcNt5\n",
+       "WqJbdWpV3btlqwUAAAAAzMVcZj5pgZ7ZlXbZQfrUbdO/i3vPrUe+HAAAAABAq9izi9axtyEHLXLQ\n",
+       "Igs9ctAiBy1y0CIHLbqNYRcAAAAA0DsMu2gdP48sBy1y0CILPXLQIgctctAiBy26bSzDru3TbV9v\n",
+       "+zrb59vezvYetpfZvtn2JbYXTbn/t2zfaPuocawZAAAAANAdIx92bU9IerOk51fVcyRtLekESadJ\n",
+       "WlZVB0i6rDmW7QMlHS/pQElHSzrbNmekg7G3IQctctAiCz1y0CIHLXLQIgctum0cQ+N9kh6RtKPt\n",
+       "bSTtKOm7ko6VdG5zn3Mlvaa5fJykC6rqkapaIekWSYeNdMUAAAAAgE4Z+bBbVXdL+mNJt2kw5K6p\n",
+       "qmWSFlfV6uZuqyUtbi7vLWnl0FOslLTPiJaLzcDehhy0yEGLLPTIQYsctMhBixy06LZxvI35RySd\n",
+       "ImlCg0F2Z9tvGL5PVZWk2sjTbOw2AAAAAMACt80YXvNQSf9SVXdJku2LJL1Y0h22n1ZVd9jeS9Kd\n",
+       "zf1XSVoy9Ph9m+s2YHuppBXN4RpJ10x+N2by/fbrvzvz0YnBrP+WFeuPh1yliWa1Kx4/XqunDL3W\n",
+       "E56P4/XHw3sbEtazkI8nr0tZzwI/Priqzgpaz0I/pkfO8SnayN/XHPP390I8nrwuZT0L/Ji/L8b8\n",
+       "71/S5AcXT2iOXDXak6S2D5L0SUkvkPSgpKWSrpD0Q5LuqqozbZ8maVFVnebBB1Sdr8E+3X0kXSpp\n",
+       "/5qycNtVVZ7dGg45R7rytmlPbO++5/E66e6LtbMe2uC287REt+rUqrp31l/wAmT7iMnfpBgvWuSg\n",
+       "RRZ65KBFDlrkoEUOWmSZy8wnjeHMblVda/svJV0l6TFJX5P0UUm7SLrQ9kkanJ19fXP/5bYvlLRc\n",
+       "0jpJJ08ddJGF/yDkoEUOWmShRw5a5KBFDlrkoEW3jeNtzKqq90l635Sr75Z05Az3P0PSGfO9LgAA\n",
+       "AABAP/DzatG64f0mGC9a5KBFFnrkoEUOWuSgRQ5adBvDLgAAAACgdxh20Tr2NuSgRQ5aZKFHDlrk\n",
+       "oEUOWuSgRbcx7AIAAAAAeodhF61jb0MOWuSgRRZ65KBFDlrkoEUOWnQbwy4AAAAAoHcYdtE69jbk\n",
+       "oEUOWmShRw5a5KBFDlrkoEW3MewCAAAAAHqHYRetY29DDlrkoEUWeuSgRQ5a5KBFDlp0G8MuAAAA\n",
+       "AKB3GHbROvY25KBFDlpkoUcOWuSgRQ5a5KBFtzHsAgAAAAB6h2EXrWNvQw5a5KBFFnrkoEUOWuSg\n",
+       "RQ5adBvDLgAAAACgdxh20Tr2NuSgRQ5aZKFHDlrkoEUOWuSgRbcx7AIAAAAAeodhF61jb0MOWuSg\n",
+       "RRZ65KBFDlrkoEUOWnQbwy4AAAAAoHcYdtE69jbkoEUOWmShRw5a5KBFDlrkoEW3MewCAAAAAHqH\n",
+       "YRetY29DDlrkoEUWeuSgRQ5a5KBFDlp0G8MuAAAAAKB3GHbROvY25KBFDlpkoUcOWuSgRQ5a5KBF\n",
+       "tzHsAgAAAAB6h2EXrWNvQw5a5KBFFnrkoEUOWuSgRQ5adBvDLgAAAACgdxh20Tr2NuSgRQ5aZKFH\n",
+       "DlrkoEUOWuSgRbcx7AIAAAAAeodhF61jb0MOWuSgRRZ65KBFDlrkoEUOWnQbwy4AAAAAoHcYdtE6\n",
+       "9jbkoEUOWmShRw5a5KBFDlrkoEW3MewCAAAAAHqHYRetY29DDlrkoEUWeuSgRQ5a5KBFDlp0G8Mu\n",
+       "AAAAAKB3GHbROvY25KBFDlpkoUcOWuSgRQ5a5KBFtzHsAgAAAAB6h2EXrWNvQw5a5KBFFnrkoEUO\n",
+       "WuSgRQ5adBvDLgAAAACgdzY57Nq+2vbbbO8+igWh+9jbkIMWOWiRhR45aJGDFjlokYMW3TabM7sn\n",
+       "SNpH0pW2P2X7p2x7ntcFAAAAAMBm2+SwW1XfqqrflXSApPMlnSPpNtv/0/Ye871AdA97G3LQIgct\n",
+       "stAjBy1y0CIHLXLQottmtWfX9kGS/kTS+yX9taTXSVor6R/mb2kAAAAAAGyebTZ1B9tXS7pX0sck\n",
+       "/U5VPdTc9G+2Xzqfi0M3sbchBy1y0CILPXLQIgctctAiBy26bZPDrqTXVdW3p7uhqn6m5fUAAAAA\n",
+       "ALDFZvM25l+2vWjywPbutt8zj2tCx7G3IQctctAiCz1y0CIHLXLQIgctum02w+4rq2rN5EFV3SPp\n",
+       "VfO3JAAAAAAAtsxsht2tbG8/eWB7B0nbzt+S0HXsbchBixy0yEKPHLTIQYsctMhBi26bzZ7dT0q6\n",
+       "zPY5kizpTZL+cl5XBQAAAADAFpjNz9k9U9J7JB0o6Ucl/UFzHTAt9jbkoEUOWmShRw5a5KBFDlrk\n",
+       "oEW3zebMrqrqC5K+MM9rAQAAAACgFZs8s2v7tba/Zfs+22ubX/eNYnHoJvY25KBFDlpkoUcOWuSg\n",
+       "RQ5a5KBFt83mzO77JB1TVTfM92IAAAAAAGjDbD6N+Q4GXcwFexty0CIHLbLQIwctctAiBy1y0KLb\n",
+       "ZnNm9yrb/0/SxZIebq6rqrpo/pYFAAAAAMDmm82wu5uk/5R01JTrGXYxLfY25KBFDlpkoUcOWuSg\n",
+       "RQ5a5KBFt21y2K2qXxrBOgAAAAAAaM1sPo35mbYvs319c/xc27+/JS9qe5HtT9u+wfZy2y+0vYft\n",
+       "ZbZvtn2J7UVD9z+9+UToG21PPcOMMOxtyEGLHLTIQo8ctMhBixy0yEGLbpvNB1T9haTf1fr9utdJ\n",
+       "OnELX/cDkj5fVc+S9FxJN0o6TdKyqjpA0mXNsWwfKOl4SQdKOlrS2bZns24AAAAAwAI1m6Fxx6q6\n",
+       "fPKgqkrSI5v7grZ3k/Tyqjqneb51VXWvpGMlndvc7VxJr2kuHyfpgqp6pKpWSLpF0mGb+/qYf+xt\n",
+       "yEGLHLTIQo8ctMhBixy0yEGLbpvNsPt92/tPHtj+r5K+twWvuV/znJ+w/TXbf2F7J0mLq2p1c5/V\n",
+       "khY3l/eWtHLo8Ssl7bMFrw8AAAAA6LnZDLu/Jukjkn7U9ncl/bqkX92C19xG0vMlnV1Vz5f0gJq3\n",
+       "LE9qzh7XRp5jY7dhzNjbkIMWOWiRhR45aJGDFjlokYMW3TabT2O+VdIrmrOvW1XV2i18zZWSVlbV\n",
+       "lc3xpyWdLukO20+rqjts7yXpzub2VZKWDD1+3+a6DdheKmlFc7hG0jWTbz2Y/I26/q0IH50YzPpv\n",
+       "WbH+eMhVGhwf2jzfVZrQWj1l6LWe8Hwcc5x4PCllPQv8+GBJSetZ6Mf0CDmWdLDtmPVwzHHC8aSU\n",
+       "9SzwY/6+GP+//8kPLp7QHLlq4ydJbb9LUkly8081i/iDub7Y0HP+o6Rfrqqbbb9b0o7NTXdV1Zm2\n",
+       "T5O0qKpO8+ADqs7XYJ/uPpIulbR/TVm47aoqz+71DzlHuvK2aU9s777n8Trp7ou1sx7a4LbztES3\n",
+       "6tQa7DEGAAAAAIzIXGY+aRZndjV4m/HkYLmDpGMkLd+MtQ3775I+aXtbSbdKepOkrSVdaPskDc7O\n",
+       "vl6Sqmq57Qub11wn6eSpgy4AAAAAAMNm8zbm/z18bPv9ki7ZkhetqmslvWCam46c4f5nSDpjS14T\n",
+       "o2P7iKG3p2GMaJGDFlnokYMWOWiRgxY5aNFtm/PzancSn4YMAAAAAAi2yTO7tq8bOtxK0lMlbfZ+\n",
+       "XfQf3/3KQYsctMhCjxy0yEGLHLTIQYtum82e3VcPXV4naXVVPTJP6wEAAAAAYIvN5m3M9w39+oGk\n",
+       "XWzvMflrXleHTpr6sfkYH1rkoEUWeuSgRQ5a5KBFDlp022zO7H5N0tMl3dMc7y7pNg0+obkk/fD8\n",
+       "LA0AAAAAgM0zmzO7yyQdU1V7VtWekl4l6ZKq2q+qGHSxAfY25KBFDlpkoUcOWuSgRQ5a5KBFt81m\n",
+       "2H1xVX1+8qCqviDpJfO3JAAAAAAAtsxsht3v2v592xO297P9e5JWzffC0F3sbchBixy0yEKPHLTI\n",
+       "QYsctMhBi26bzbB7ogY/buhvJF3UXD5xPhcFAAAAAMCW2OQHVFXVXZLebnunqnpgBGtCx7G3IQct\n",
+       "ctAiCz1y0CIHLXLQIgctum2TZ3Ztv8T2ckk3NscH2T573lcGAAAAAMBmms3bmM+SdLSk/5CkqrpW\n",
+       "0uHzuSh0G3sbctAiBy2y0CMHLXLQIgctctCi22Yz7Kqqbpty1bp5WAsAAAAAAK3Y5J5dSbfZfqkk\n",
+       "2d5W0tsl3TCvq0KnsbchBy1y0CILPXLQIgctctAiBy26bTZndn9F0tsk7aPBjxx6XnMMAAAAAECk\n",
+       "jQ67treR9IGq+rmqempVPaWqfr75hGZgWuxtyEGLHLTIQo8ctMhBixy0yEGLbtvosFtV6yT9kO3t\n",
+       "RrQeAAAAAAC22Gz27H5b0j/b/oykHzTXVVX9yfwtC13G3oYctMhBiyz0yEGLHLTIQYsctOi2Gc/s\n",
+       "2j6vuXispL9r7rtz82uX+V8aAAAAAACbZ2NvYz7E9t6SbpP0IUl/NuUXMC32NuSgRQ5aZKFHDlrk\n",
+       "oEUOWuSgRbdt7G3M/0fSZZJ+WNLVU26r5noAAAAAAOLMeGa3qj5YVc+S9Imq2m/KLwZdzIi9DTlo\n",
+       "kYMWWeiRgxY5aJGDFjlo0W2b/Dm7VfUro1gIAAAAAABt2eSwC8wVexty0CIHLbLQIwctctAiBy1y\n",
+       "0KLbGHYBAAAAAL3DsIvWsbchBy1y0CILPXLQIgctctAiBy26jWEXAAAAANA7DLtoHXsbctAiBy2y\n",
+       "0CMHLXLQIgctctCi2xh2AQAAAAC9w7CL1rG3IQctctAiCz1y0CIHLXLQIgctuo1hFwAAAADQOwy7\n",
+       "aB17G3LQIgctstAjBy1y0CIHLXLQotsYdgEAAAAAvcOwi9axtyEHLXLQIgs9ctAiBy1y0CIHLbqN\n",
+       "YRcAAAAA0DsMu2gdexty0CIHLbLQIwctctAiBy1y0KLbGHYBAAAAAL3DsIvWsbchBy1y0CILPXLQ\n",
+       "IgctctDy9JzLAAAY50lEQVQiBy26jWEXAAAAANA7DLtoHXsbctAiBy2y0CMHLXLQIgctctCi2xh2\n",
+       "AQAAAAC9w7CL1rG3IQctctAiCz1y0CIHLXLQIgctuo1hFwAAAADQOwy7aB17G3LQIgctstAjBy1y\n",
+       "0CIHLXLQotsYdgEAAAAAvcOwi9axtyEHLXLQIgs9ctAiBy1y0CIHLbqNYRcAAAAA0DsMu2gdexty\n",
+       "0CIHLbLQIwctctAiBy1y0KLbGHYBAAAAAL3DsIvWsbchBy1y0CILPXLQIgctctAiBy26jWEXAAAA\n",
+       "ANA7DLtoHXsbctAiBy2y0CMHLXLQIgctctCi2xh2AQAAAAC9w7CL1rG3IQctctAiCz1y0CIHLXLQ\n",
+       "Igctuo1hFwAAAADQOwy7aB17G3LQIgctstAjBy1y0CIHLXLQotsYdgEAAAAAvTO2Ydf21ra/bvuz\n",
+       "zfEetpfZvtn2JbYXDd33dNvfsn2j7aPGtWbMDnsbctAiBy2y0CMHLXLQIgctctCi28Z5ZvcdkpZL\n",
+       "qub4NEnLquoASZc1x7J9oKTjJR0o6WhJZ9vmjDQAAAAAYEZjGRpt7yvplZI+JsnN1cdKOre5fK6k\n",
+       "1zSXj5N0QVU9UlUrJN0i6bDRrRZzxd6GHLTIQYss9MhBixy0yEGLHLTotnGdIf1TSb8l6bGh6xZX\n",
+       "1erm8mpJi5vLe0taOXS/lZL2mfcVAgAAAAA6a+TDru1jJN1ZVV/X+rO6T1BVpfVvb572LvOxNrSD\n",
+       "vQ05aJGDFlnokYMWOWiRgxY5aNFt24zhNV8i6Vjbr5S0vaRdbZ8nabXtp1XVHbb3knRnc/9VkpYM\n",
+       "PX7f5roN2F4qaUVzuEbSNZO/QSffgrD+N+xHJwaz/ltWrD8ecpUGx4c2z3eVJrRWTxl6rSc8H8cc\n",
+       "c8wxxxxzzDHHHHPMMcetHh8safKDiyc0R64a30lS24dL+s2qerXt90m6q6rOtH2apEVVdZoHH1B1\n",
+       "vgb7dPeRdKmk/WvKwm1XVU17pnjD1z3kHOnK26Y9sb37nsfrpLsv1s56aIPbztMS3apTq+reOX6p\n",
+       "C4rtIyZ/k2K8aJGDFlnokYMWOWiRgxY5aJFlLjOfNJ4zu1NNDq3vlXSh7ZM0ODv7ekmqquW2L9Tg\n",
+       "k5vXSTp56qALAAAAAMCwsZ7ZbRNndgEAAACgv+Z6ZpefVwsAAAAA6B2GXbRucnM5xo8WOWiRhR45\n",
+       "aJGDFjlokYMW3cawCwAAAADoHYZdtI5PrMtBixy0yEKPHLTIQYsctMhBi25j2AUAAAAA9A7DLlrH\n",
+       "3oYctMhBiyz0yEGLHLTIQYsctOg2hl0AAAAAQO8w7KJ17G3IQYsctMhCjxy0yEGLHLTIQYtuY9gF\n",
+       "AAAAAPQOwy5ax96GHLTIQYss9MhBixy0yEGLHLToNoZdAAAAAEDvMOyidextyEGLHLTIQo8ctMhB\n",
+       "ixy0yEGLbmPYBQAAAAD0DsMuWsfehhy0yEGLLPTIQYsctMhBixy06DaGXQAAAABA7zDsonXsbchB\n",
+       "ixy0yEKPHLTIQYsctMhBi25j2AUAAAAA9A7DLlrH3oYctMhBiyz0yEGLHLTIQYsctOg2hl0AAAAA\n",
+       "QO8w7KJ17G3IQYsctMhCjxy0yEGLHLTIQYtuY9gFAAAAAPQOwy5ax96GHLTIQYss9MhBixy0yEGL\n",
+       "HLToNoZdAAAAAEDvMOyidextyEGLHLTIQo8ctMhBixy0yEGLbmPYBQAAAAD0DsMuWsfehhy0yEGL\n",
+       "LPTIQYsctMhBixy06DaGXQAAAABA7zDsonXsbchBixy0yEKPHLTIQYsctMhBi25j2AUAAAAA9A7D\n",
+       "LlrH3oYctMhBiyz0yEGLHLTIQYsctOg2hl0AAAAAQO8w7KJ17G3IQYsctMhCjxy0yEGLHLTIQYtu\n",
+       "Y9gFAAAAAPQOwy5ax96GHLTIQYss9MhBixy0yEGLHLToNoZdAAAAAEDvMOyidextyEGLHLTIQo8c\n",
+       "tMhBixy0yEGLbmPYBQAAAAD0DsMuWsfehhy0yEGLLPTIQYsctMhBixy06DaGXQAAAABA7zDsonXs\n",
+       "bchBixy0yEKPHLTIQYsctMhBi25j2AUAAAAA9A7DLlrH3oYctMhBiyz0yEGLHLTIQYsctOg2hl0A\n",
+       "AAAAQO8w7KJ17G3IQYsctMhCjxy0yEGLHLTIQYtuY9gFAAAAAPQOwy5ax96GHLTIQYss9MhBixy0\n",
+       "yEGLHLToNoZdAAAAAEDvMOyidextyEGLHLTIQo8ctMhBixy0yEGLbmPYBQAAAAD0DsMuWsfehhy0\n",
+       "yEGLLPTIQYsctMhBixy06DaGXQAAAABA7zDsonXsbchBixy0yEKPHLTIQYsctMhBi25j2AUAAAAA\n",
+       "9A7DLlrH3oYctMhBiyz0yEGLHLTIQYsctOg2hl0AAAAAQO8w7KJ17G3IQYsctMhCjxy0yEGLHLTI\n",
+       "QYtuG/mwa3uJ7S/Zvt72N22/vbl+D9vLbN9s+xLbi4Yec7rtb9m+0fZRo14zAAAAAKBbxnFm9xFJ\n",
+       "v15Vz5b0Iklvs/0sSadJWlZVB0i6rDmW7QMlHS/pQElHSzrbNmekg7G3IQctctAiCz1y0CIHLXLQ\n",
+       "Igctum3kQ2NV3VFV1zSX75d0g6R9JB0r6dzmbudKek1z+ThJF1TVI1W1QtItkg4b6aIBAAAAAJ0y\n",
+       "1jOktickPU/S5ZIWV9Xq5qbVkhY3l/eWtHLoYSs1GI4Rir0NOWiRgxZZ6JGDFjlokYMWOWjRbWMb\n",
+       "dm3vLOmvJb2jqtYO31ZVJak28vCN3QYAAAAAWOC2GceL2n6SBoPueVV1cXP1attPq6o7bO8l6c7m\n",
+       "+lWSlgw9fN/muumed6mkFc3hGknXTH43ZvL99uu/O/PRicGs/5YV64+HXKXB8aHN812lCa3VU4Ze\n",
+       "6wnPx/H64+G9DQnrWcjHk9elrGeBHx9cVWcFrWehH9Mj5/gUbeTva475+3shHk9el7KeBX7M3xdj\n",
+       "/vcvafKDiyc0R64a7UlS29ZgT+5dVfXrQ9e/r7nuTNunSVpUVad58AFV52uwT3cfSZdK2r+mLNx2\n",
+       "VZVnt4ZDzpGuvG3aE9u773m8Trr7Yu2shza47Twt0a06tarune3XuxDZPmLyNynGixY5aJGFHjlo\n",
+       "kYMWOWiRgxZZ5jLzSeM5s/tSSW+Q9A3bX2+uO13SeyVdaPskDc7Ovl6Sqmq57QslLZe0TtLJUwdd\n",
+       "ZOE/CDlokYMWWeiRgxY5aJGDFjlo0W0jH3ar6p81817hI2d4zBmSzpi3RQEAAAAAeoWfV4vWDe83\n",
+       "wXjRIgctstAjBy1y0CIHLXLQotsYdgEAAAAAvcOwi9axtyEHLXLQIgs9ctAiBy1y0CIHLbqNYRcA\n",
+       "AAAA0DsMu2gdexty0CIHLbLQIwctctAiBy1y0KLbGHYBAAAAAL3DsIvWsbchBy1y0CILPXLQIgct\n",
+       "ctAiBy26jWEXAAAAANA7DLtoHXsbctAiBy2y0CMHLXLQIgctctCi2xh2AQAAAAC9w7CL1rG3IQct\n",
+       "ctAiCz1y0CIHLXLQIgctuo1hFwAAAADQOwy7aB17G3LQIgctstAjBy1y0CIHLXLQotsYdgEAAAAA\n",
+       "vcOwi9axtyEHLXLQIgs9ctAiBy1y0CIHLbqNYRcAAAAA0DsMu2gdexty0CIHLbLQIwctctAiBy1y\n",
+       "0KLbGHYBAAAAAL3DsIvWsbchBy1y0CILPXLQIgctctAiBy26jWEXAAAAANA7DLtoHXsbctAiBy2y\n",
+       "0CMHLXLQIgctctCi2xh2AQAAAAC9w7CL1rG3IQctctAiCz1y0CIHLXLQIgctuo1hFwAAAADQOwy7\n",
+       "aB17G3LQIgctstAjBy1y0CIHLXLQotsYdgEAAAAAvcOwi9axtyEHLXLQIgs9ctAiBy1y0CIHLbqN\n",
+       "YRcAAAAA0DsMu2gdexty0CIHLbLQIwctctAiBy1y0KLbGHYBAAAAAL3DsIvWsbchBy1y0CILPXLQ\n",
+       "IgctctAiBy26jWEXAAAAANA724x7AX3l3XyWdtKiaW98QGvq3jplxEsaGdtH8F2wDLTIQYss9MhB\n",
+       "ixy0yEGLHLToNobd+bKTFumtWjHtbR/RxEjXAgAAAAALDG9jRuv47lcOWuSgRRZ65KBFDlrkoEUO\n",
+       "WnQbwy4AAAAAoHcYdtE6fh5ZDlrkoEUWeuSgRQ5a5KBFDlp0G8MuAAAAAKB3GHbROvY25KBFDlpk\n",
+       "oUcOWuSgRQ5a5KBFtzHsAgAAAAB6hx89tAXsJWdJi6f/Wbp7bHuY9PCK0a4oAz+PLActctAiCz1y\n",
+       "0CIHLXLQIgctuo1hd4ssXiRdtWL623Z9mfTwSFcDAAAAABjgbcxoHd/9ykGLHLTIQo8ctMhBixy0\n",
+       "yEGLbmPYBQAAAAD0DsMuWsfPI8tBixy0yEKPHLTIQYsctMhBi25j2AUAAAAA9A7DLlrH3oYctMhB\n",
+       "iyz0yEGLHLTIQYsctOg2hl0AAAAAQO8w7KJ17G3IQYsctMhCjxy0yEGLHLTIQYtu4+fshvNuPks7\n",
+       "adG0Nz6gNXVvnTLiJQEAAABAPIbddDtpkd6qFdPe9hFNjHQts8Tehhy0yEGLLPTIQYsctMhBixy0\n",
+       "6DbexgwAAAAA6B2GXbSOvQ05aJGDFlnokYMWOWiRgxY5aNFtDLsAAAAAgN5hz24Ae8lZ0uLpP4Rq\n",
+       "j20Pkx5esUXPv7EPuZJa/6Ar9jbkoEUOWmShRw5a5KBFDlrkoEW3MexGWLxIumrF9Lft+jLp4U0+\n",
+       "wyYH5rc+fOGMDw79oCsAAAAA2FydGXZtHy3pLElbS/pYVZ055iWF2fKBuS22j9jYd8H4cUqjs6kW\n",
+       "GB1aZKFHDlrkoEUOWuSgRbd1Yti1vbWkP5N0pKRVkq60/ZmqumG8K1tY5jCkHizpyzM+UQd/nFKH\n",
+       "bbwFRokWWeiRgxY5aJGDFjlo0WGdGHYlHSbplqpaIUm2PyXpOEkMu6M0+yF15v3BGDVa5KBFFnrk\n",
+       "oEUOWuSgRQ5adFhXht19JN0+dLxS0gvHtBbMQhsfurXR59jh+oO06MFrp72to2+F5u3dAAAAQHu6\n",
+       "MuxWu0/34MPSO/ad9qZHH12nL2svbaV1G9z2n22vI09Lnww9IS3Wlu8h3sg+5B12fZne+uD0t015\n",
+       "K3RbQ3Mbz7PZHyS2+W/vnvFxG12L1M7X1NI3JWb7jYDNXssc1rMF35SY2NRzj8sC/UbLxLgXMFdd\n",
+       "7bTx/9asXiPOmiSZGPcCRqEjf5Ymxr0APG5C6szvG0zhqvz5zfaLJL27qo5ujk+X9Njwh1TZzv9C\n",
+       "AAAAAACbrao82/t2ZdjdRtJNkl4h6buSrpB0Ih9QBQAAAACYTifexlxV62z/mqS/1+BHD32cQRcA\n",
+       "AAAAMJNOnNkFAAAAAGAuthr3AraU7aNt32j7W7Z/Z9zrWWhsn2N7te3rhq7bw/Yy2zfbvsQ2Hz4y\n",
+       "AraX2P6S7ettf9P225vr6TFitre3fbnta2wvt/1HzfW0GBPbW9v+uu3PNse0GAPbK2x/o2lxRXMd\n",
+       "LcbA9iLbn7Z9Q/PfqRfSYjxsP7P5MzH5617bb6fHeNg+vfl/qetsn297O1qMh+13NB2+afsdzXVz\n",
+       "atHpYdf21pL+TNLRkg6UdKLtZ413VQvOJzT49z/sNEnLquoASZc1x5h/j0j69ap6tqQXSXpb8+eB\n",
+       "HiNWVQ9K+vGqOljScyX9uO2XiRbj9A5Jy7X+0/1pMR4l6Yiqel5VHdZcR4vx+ICkz1fVszT479SN\n",
+       "osVYVNVNzZ+J50k6RNIPJP2N6DFytickvVnS86vqORpsnzxBtBg52z8m6ZclvUDSQZKOsf0jmmOL\n",
+       "Tg+7kg6TdEtVraiqRyR9StJxY17TglJV/yTpnilXHyvp3ObyuZJeM9JFLVBVdUdVXdNcvl/SDRr8\n",
+       "jGp6jEFV/aC5uK0Gf1neI1qMhe19Jb1S0sckTX6CIy3GZ+qnaNJixGzvJunlVXWONPhslKq6V7RI\n",
+       "cKQG/297u+gxDvdpcPJgx+YDcnfU4MNxaTF6Pyrp8qp6sKoelfQVSa/VHFt0fdjdR9LtQ8crm+sw\n",
+       "XouranVzebUGP3QXI9R8Z/J5ki4XPcbC9la2r9Hg3/mXqup60WJc/lTSb0l6bOg6WoxHSbrU9lW2\n",
+       "39xcR4vR20/S921/wvbXbP+F7Z1EiwQnSLqguUyPEauquyX9saTbNBhy11TVMtFiHL4p6eXN25Z3\n",
+       "1OCb1vtqji26Puzy6VrhavAJaHQaIds7S/prSe+oqrXDt9FjdKrqseZtzPtK+i+2f3zK7bQYAdvH\n",
+       "SLqzqr6uDc8oSqLFiL20eavmT2uw1eLlwzfSYmS2kfR8SWdX1fMlPaApbwWkxejZ3lbSqyX91dTb\n",
+       "6DEazdtkT5E0IWlvSTvbfsPwfWgxGlV1o6QzJV0i6QuSrpH06JT7bLJF14fdVZKWDB0v0eDsLsZr\n",
+       "te2nSZLtvSTdOeb1LBi2n6TBoHteVV3cXE2PMWreGvg5DfZh0WL0XiLpWNvf0eBsyU/YPk+0GIuq\n",
+       "+l7zz+9rsCfxMNFiHFZKWllVVzbHn9Zg+L2DFmP105Kubv58SPzZGIdDJf1LVd1VVeskXSTpxeLP\n",
+       "xlhU1TlVdWhVHa7BdrCbNcc/F10fdq+S9AzbE813w46X9JkxrwmDBm9sLr9R0sUbuS9aYtuSPi5p\n",
+       "eVWdNXQTPUbM9pMnPx3Q9g6SflLS10WLkauq362qJVW1nwZvD/yHqvoF0WLkbO9oe5fm8k6SjpJ0\n",
+       "nWgxclV1h6TbbR/QXHWkpOslfVa0GKcTtf4tzBJ/NsbhRkkvsr1D8/9VR2rw4Yb82RgD209t/vl0\n",
+       "ST8r6XzN8c9F53/Oru2flnSWBh8A8/Gq+qMxL2lBsX2BpMMlPVmD983/D0l/K+lCSU+XtELS66tq\n",
+       "zbjWuFA0n/b7j5K+ofVv6Thd0hWix0jZfo4GH5qwVfPrvKp6v+09RIuxsX24pN+oqmNpMXq299Pg\n",
+       "bK40eBvtJ6vqj2gxHrYP0uBD27aVdKukN2nw/1K0GIPmG0D/Lmm/yS1I/NkYD9u/rcEQ9Zikr2nw\n",
+       "icC7iBYjZ/sfJe2p9T9x5Etz/XPR+WEXAAAAAICpuv42ZgAAAAAANsCwCwAAAADoHYZdAAAAAEDv\n",
+       "MOwCAAAAAHqHYRcAAAAA0DsMuwAAAACA3mHYBQBgI2y/2/ZvNJf/p+1XbObzHNT8bPiRsP1Ltj80\n",
+       "qtfbyDqOs/2sca8DALDwMOwCALBxj/9A+qp6V1VdtpnP8zxJr9zcRdie69/Ztem7jMTPSDpw3IsA\n",
+       "ACw8DLsAADRs/6Lta21fY/vcaW5favu1zeVDbH/Z9lW2v2j7ac31X7b9XtuX277J9stsP0nSH0g6\n",
+       "3vbXbb9uyvNubft/276uef23NdevaJ7rakmvs/3Ltq9o1vdp2zs093td89hrbH958mkl7W37C7Zv\n",
+       "tn3mDF/zC2x/tXns5bZ3sr297U/Y/obtr9k+ornvE84W2/472/+luXy/7fc0z/Ovtp9q+yWSXi3p\n",
+       "/c3X/cObHQcAgDnaZtwLAAAgge1nS/o9SS+uqrttL5rmbiWpmuH1Q5JeXVV32T5e0h9KOqm5z9ZV\n",
+       "9cLmbcvvqqqftP1OSYdU1duned63SHq6pIOq6jHbuw+93n9U1SHNGveoqo81l/9X83p/Jumdko6q\n",
+       "qu/Z3nXoeQ9ufj0s6SbbH6yqVUNf87aSPiXp9VV1te2dJT0o6RRJj1bVc20/U9Iltg/QhmeLh493\n",
+       "lPSvVfX7zWD95qr6Q9ufkfTZqrpomq8bAIB5w7ALAMDAT0i6sKrulqSqWjPD/SzpmZKeLelS25K0\n",
+       "taTvDt1ncrD7mqSJocd5hud8haQ/r6rHmte+Z+i2/zd0+Tm23yNpN0k7S/pic/1XJZ1r+8Kh1y5J\n",
+       "l1XVWkmyvbxZy6qh53umpO9V1dXN697f3Pelkj7YXHeT7X+XdMAMa5/0cFV9rrl8taSfHLptpq8b\n",
+       "AIB5w7ALAMBAaeahbLr9r9dX1UtmuP9DzT8f1ez/rp3ptR8YurxU0rFVdZ3tN0o6QpKq6ldtHybp\n",
+       "VZKutn1I83wPDT32UQ2G8tmaup6StE5P3AK1/dDlR4YuP6Ynft0p+4cBAAsIe3YBABj4Bw32xe4h\n",
+       "SUNvJZaeOPiVpJskPcX2i5r7Psn2pj6E6T5Ju8xw2zJJb7W99TSvPWxnSXc0b6N+w+OLs3+kqq6o\n",
+       "qndJ+r6kJZp+wJw6wN4kaS/bhzbPs0uzhn+S9PPNdQdo8BbrmyStkHSwB5ZIOmzjX7Ikaa2kXTd5\n",
+       "LwAAWsawCwCApKparsG+26/YvkbSHw/fPOW+j0j6r5LObO77dUkvnumpm39+SdKB031AlaSPSbpN\n",
+       "0jea5ztxhud6p6TLJf2zpBuGnvt9zYdJXSfpq1V17XTrnubreFjS8ZI+1Lzu30vaTtLZkray/Q0N\n",
+       "9vS+saoeqaqvSvqOpOWSPqDB25Wne+4aOv6UpN+yfTUfUAUAGCVX8c4iAAAAAEC/cGYXAAAAANA7\n",
+       "DLsAAAAAgN5h2AUAAAAA9A7DLgAAAACgdxh2AQAAAAC9w7ALAAAAAOgdhl0AAAAAQO8w7AIAAAAA\n",
+       "euf/A1zWxT+3RbM8AAAAAElFTkSuQmCC\n"
+      ],
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f932c51d7d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data = (e10s_crashes_per_client.values(), non_e10s_crashes_per_client.values())\n",
+    "plt.hist(data, label=(\"e10s\", \"non-e10s\"), histtype='bar', bins=45, alpha=0.5)\n",
+    "plt.grid(True)\n",
+    "plt.xlabel(\"client crash count\")\n",
+    "plt.ylabel(\"frequency\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Some crash pings don't have `clientId` at all so I excluded those pings from the 'not first ping' check (i.e. they are treated as if they are not the first ping).