### PR TITLE
Add top addons experiment

### DIFF
--- a/aurora/addons/top_extensions.ipynb
+++ b/aurora/addons/top_extensions.ipynb
@@ -1,0 +1,506 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### E10S Experiment Aurora: Top extensions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Bug 1224518](https://bugzilla.mozilla.org/show_bug.cgi?id=1224518)\n",
+    "\n",
+    "This analysis lists the top extensions in the Telemetry pings and compares them to the [whitelisted e10s addon list](https://wiki.mozilla.org/Electrolysis/Addons)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unable to parse whitelist (/home/hadoop/anaconda/lib/python2.7/site-packages/moztelemetry/bucket-whitelist.json). Assuming all histograms are acceptable.\n",
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ujson as json\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.plotly as py\n",
+    "import IPython\n",
+    "\n",
+    "from __future__ import division\n",
+    "from moztelemetry.spark import get_pings, get_one_ping_per_client, get_pings_properties\n",
+    "from montecarlino import grouped_permutation_test\n",
+    "\n",
+    "%pylab inline\n",
+    "IPython.core.pylabtools.figsize(16, 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "16"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.defaultParallelism"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Whitelisted addons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Fetched from https://wiki.mozilla.org/Electrolysis/Addons\n",
+    "# Some entries have been commented out because the addon ID could not be determined.\n",
+    "whitelisted_addons = {\n",
+    "    # Broken\n",
+    "    \"YoutubeDownloader@PeterOlayev.com\":                \"1-Click YouTube Video Downloader\",\n",
+    "    \"wrc@avast.com\":                                    \"Avast Online Security\",\n",
+    "    \"abs@avira.com\":                                    \"Avira Browser Safety\",\n",
+    "    \"translator@zoli.bod\":                              \"Google Translator for Firefox\",\n",
+    "    \"firefox@ghostery.com\":                             \"Ghostery\",\n",
+    "    \"{3d7eb24f-2740-49df-8937-200b1cc08f8a}\":           \"Flashblock\",\n",
+    "    \"{635abd67-4fe9-1b23-4f01-e679fa7484c1}\":           \"Yahoo! Toolbar\",\n",
+    "    \"{7affbfae-c4e2-4915-8c0f-00fa3ec610a1}\":           \"Aol Toolbar\",\n",
+    "    \"jid1-F9UJ2thwoAm5gQ@jetpack\":                      \"Lightbeam\",\n",
+    "    \"{1BC9BA34-1EED-42ca-A505-6D2F1A935BBB}\":           \"IE Tab 2\",\n",
+    "\n",
+    "    # Somewhat working/uses CPOWs\n",
+    "    \"{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}\":           \"Adblock Plus\",\n",
+    "    \"adblockpopups@jessehakanen.net\":                   \"Adblock Plus Pop-up Addon\",\n",
+    "    \"avg@toolbar\":                                      \"AVG SafeGuard toolbar\",\n",
+    "    \"elemhidehelper@adblockplus.org\":                   \"Element Hiding Helper for Adblock Plus\",\n",
+    "    \"{73a6fe31-595d-460b-a920-fcc0f8843232}\":           \"NoScript\",\n",
+    "    \"{19503e42-ca3c-4c27-b1e2-9cdb2170ee34}\":           \"FlashGot\",\n",
+    "    \"mozilla_cc2@internetdownloadmanager.com\":          \"IDM CC\",\n",
+    "    \"yasearch@yandex.ru\":                               \"Yandex Elements\",\n",
+    "    \"support@lastpass.com\":                             \"LastPass\",\n",
+    "    \"{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}\":           \"WOT\",\n",
+    "    \"artur.dubovoy@gmail.com\":                          \"Flash Video Downloader - YouTube HD Download [4K]\",\n",
+    "    \"onepassword4@agilebits.com\":                       \"1Password\",\n",
+    "\n",
+    "    # Totally working\n",
+    "    \"cck2wizard@kaply.com\":                             \"CCK2\",\n",
+    "    \"firebug@software.joehewitt.com\":                   \"Firebug\",\n",
+    "    \"{2b10c1c8-a11f-4bad-fe9c-1c11e82cac42}\":           \"uBlock\",\n",
+    "    \"{46551EC9-40F0-4e47-8E18-8E5CF550CFB8}\":           \"Stylish\",\n",
+    "    \"{dc572301-7619-498c-a57d-39143191b318}\":           \"Tab Mix Plus\",\n",
+    "    \"jid1-YcMV6ngYmQRA2w@jetpack\":                      \"Pin It button\",\n",
+    "    \"{e4f94d1e-2f53-401e-8885-681602c0ddd8}\":           \"McAfee Security Scan Plus\",\n",
+    "    \"https-everywhere@eff.org\":                         \"HTTPS-Everywhere\",\n",
+    "    \"url_advisor@kaspersky.com\":                        \"Kaspersky URL Advisor\",\n",
+    "    \"abb@amazon.com\":                                   \"Amazon 1Button App for Firefox\",\n",
+    "    \"{a7c6cf7f-112c-4500-a7ea-39801a327e5f}\":           \"FireFTP\",\n",
+    "    \"personas@christopher.beard\":                       \"Personas Plus\",\n",
+    "    \"mozsocial.cliqz.com@services.mozilla.org\":         \"Cliqz\",\n",
+    "    \"{6c28e999-e900-4635-a39d-b1ec90ba0c0f}\":           \"Download Status Bar\",\n",
+    "    \"{e4a8a97b-f2ed-450b-b12d-ee082ba24781}\":           \"Greasemonkey\",\n",
+    "    #                                                   \"United Internet Addons\",\n",
+    "    \"verticaltabs@mozilla.com\":                         \"Vertical Tabs\",\n",
+    "    \"{b9db16a4-6edc-47ec-a1f4-b86292ed211d}\":           \"Video DownloadHelper\",\n",
+    "    \"foxmarks@kei.com\":                                 \"Xmarks\",\n",
+    "    \"{0545b830-f0aa-4d7e-8820-50a4629a56fe}\":           \"ColorfulTabs\",\n",
+    "    \"{b9bfaf1c-a63f-47cd-8b9a-29526ced9060}\":           \"Download YouTube Videos as MP4\",\n",
+    "    \"{DDC359D1-844A-42a7-9AA1-88A850A938A8}\":           \"DownThemAll!\",\n",
+    "    \"{1018e4d6-728f-4b20-ad56-37578a4de76b}\":           \"Flagfox\",\n",
+    "    \"extension@one-tab.com\":                            \"OneTab\",\n",
+    "    \"feca4b87-3be4-43da-a1b1-137c24220968@jetpack\":     \"YouTube Video and Audio Downloader\",\n",
+    "\n",
+    "    # Other\n",
+    "    \"firefox@mega.co.nz\":                               \"MEGA\",\n",
+    "    #                                                   \"Norton Toolbar\",\n",
+    "    \"{4ED1F68A-5463-4931-9384-8FFF5ED91D92}\":           \"McAfee WebAdvisor\",\n",
+    "    \"vb@yandex.ru\":                                     \"Yandex Visual Bookmarks\",\n",
+    "    \"{ef4e370e-d9f0-4e00-b93e-a4f274cfdd5a}\":           \"FoxTab\",\n",
+    "    #                                                   \"LogMeIn Remote Access\",\n",
+    "    \"{195A3098-0BD5-4e90-AE22-BA1C540AFD1E}\":           \"Garmin Communicator\",\n",
+    "    #                                                   \"IBM CCK\",\n",
+    "    \"{fe272bd1-5f76-4ea4-8501-a05d35d823fc}\":           \"Adblock Edge\",\n",
+    "    \"{87F8774F-B485-47E2-A755-A40A8A5E8874}\":           \"GBBD Banco Santander (Brasil) S.A.\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Get addons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dataset = sqlContext.load(\"s3://telemetry-parquet/e10s-experiment/generationDate=20151117\", \"parquet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Transform Dataframe to RDD of pings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def row_2_ping(row):\n",
+    "    ping = {\"environment\": {\"addons\": json.loads(row.addons)}}\n",
+    "    return ping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "subset = dataset.rdd.map(row_2_ping)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def get_ping_addons(ping):\n",
+    "    activeAddons = ping[\"environment\"][\"addons\"].get(\"activeAddons\", {})\n",
+    "    for k, v in activeAddons.iteritems():\n",
+    "        if v.get(\"name\"):\n",
+    "            yield (k, v[\"name\"].encode(\"ascii\", \"ignore\"))\n",
+    "\n",
+    "addons = subset.flatMap(get_ping_addons)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "addon_counts = addons.countByKey()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many addons did the clients have?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "177157"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "total_addons = sum(addon_counts.values())\n",
+    "total_addons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which whitelisted addons did not appear in the pings?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aol Toolbar\n",
+      "AVG SafeGuard toolbar\n"
+     ]
+    }
+   ],
+   "source": [
+    "for addon in whitelisted_addons:\n",
+    "    if not addon in addon_counts:\n",
+    "        print whitelisted_addons[addon]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Top whitelisted addons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8.850%: Adblock Plus\n",
+      "1.767%: Video DownloadHelper\n",
+      "1.682%: Firebug\n",
+      "1.014%: DownThemAll!\n",
+      "0.928%: Greasemonkey\n",
+      "0.711%: Download YouTube Videos as MP4\n",
+      "0.672%: Ghostery\n",
+      "0.587%: Flash Video Downloader - YouTube HD Download [4K]\n",
+      "0.580%: NoScript\n",
+      "0.563%: LastPass\n",
+      "0.535%: Stylish\n",
+      "0.496%: YouTube Video and Audio Downloader\n",
+      "0.455%: Adblock Plus Pop-up Addon\n",
+      "0.451%: FireFTP\n",
+      "0.439%: Tab Mix Plus\n",
+      "0.438%: FlashGot\n",
+      "0.413%: Google Translator for Firefox\n",
+      "0.400%: WOT\n",
+      "0.397%: Flagfox\n",
+      "0.388%: 1-Click YouTube Video Downloader\n",
+      "0.360%: Adblock Edge\n",
+      "0.349%: uBlock\n",
+      "0.317%: Element Hiding Helper for Adblock Plus\n",
+      "0.308%: IDM CC\n",
+      "0.278%: Lightbeam\n",
+      "0.185%: Download Status Bar\n",
+      "0.177%: Kaspersky URL Advisor\n",
+      "0.163%: Xmarks\n",
+      "0.159%: Personas Plus\n",
+      "0.152%: HTTPS-Everywhere\n",
+      "0.145%: 1Password\n",
+      "0.125%: MEGA\n",
+      "0.125%: Yandex Elements\n",
+      "0.111%: IE Tab 2\n",
+      "0.096%: Pin It button\n",
+      "0.094%: ColorfulTabs\n",
+      "0.086%: Flashblock\n",
+      "0.062%: OneTab\n",
+      "0.040%: Garmin Communicator\n",
+      "0.020%: Amazon 1Button App for Firefox\n",
+      "0.019%: Yandex Visual Bookmarks\n",
+      "0.014%: Avira Browser Safety\n",
+      "0.013%: Avast Online Security\n",
+      "0.010%: McAfee WebAdvisor\n",
+      "0.007%: FoxTab\n",
+      "0.004%: McAfee Security Scan Plus\n",
+      "0.002%: GBBD Banco Santander (Brasil) S.A.\n",
+      "0.001%: Cliqz\n",
+      "0.001%: CCK2\n",
+      "0.001%: Vertical Tabs\n",
+      "0.001%: Yahoo! Toolbar\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "for addon, addon_count in Counter(addon_counts).most_common():\n",
+    "    if addon in whitelisted_addons:\n",
+    "        print \"{:.3f}%: {}\".format(100.0 * addon_count / total_addons, whitelisted_addons[addon])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Top unwhitelisted addons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# An addon ID might have multiple names. Pick the longer one because some addons appear to have\n",
+    "# invalid names (e.g. single space).\n",
+    "addon_names = addons.reduceByKey(lambda a, b: a if len(a) > len(b) else b).collectAsMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13.962%: ADB Helper (adbhelper@mozilla.org)\n",
+      "13.574%: Valence (fxdevtools-adapters@mozilla.org)\n",
+      "1.165%: Web Developer ({c45c406e-ab73-11d8-be73-000a95be3b12})\n",
+      "0.996%: uBlock Origin (uBlock0@raymondhill.net)\n",
+      "0.710%: ColorZilla ({6AC85730-7D0F-4de0-B3FA-21142DD85326})\n",
+      "0.512%: User Agent Switcher ({e968fc70-8f95-4ab9-9e79-304de2a71ee1})\n",
+      "0.401%: MeasureIt ({75CEEE46-9B64-46f8-94BF-54012DE155F0})\n",
+      "0.387%: JSONView (jsonview@brh.numbera.com)\n",
+      "0.382%: Reddit Enhancement Suite (jid1-xUfzOsOFlzSOXg@jetpack)\n",
+      "0.357%: S3.Google Translator (s3google@translator)\n",
+      "0.349%: Awesome screenshot: Capture and Annotate (jid0-GXjLLfbCoAx0LcltEdFrEkQdQPI@jetpack)\n",
+      "0.334%: ZenMate Security, Privacy & Unblock VPN (firefox@zenmate.com)\n",
+      "0.331%: FireGestures (firegestures@xuldev.org)\n",
+      "0.305%: Module de blocage des sites Internet dangereux (content_blocker@kaspersky.com)\n",
+      "0.299%: Flash and Video Download ({bee6eb20-01e0-ebd1-da83-080329fb9a3a})\n",
+      "0.292%: RESTClient ({ad0d925d-88f8-47f1-85ea-8463569e756e})\n",
+      "0.290%: Wappalyzer (wappalyzer@crunchlabz.com)\n",
+      "0.284%: iLivid (LVD-SAE@iacsearchandmedia.com)\n",
+      "0.274%: Evernote Web Clipper ({E0B8C461-F8FB-49b4-8373-FE32E9252800})\n",
+      "0.259%: YouTube mp3 (info@youtube-mp3.org)\n",
+      "0.258%: Administrador de sesiones ({1280606b-2510-4fe0-97ef-9b5a22eafe30})\n",
+      "0.257%: YouTube Flash Player (jid1-HAV2inXAnQPIeA@jetpack)\n",
+      "0.251%: SQLite Manager (SQLiteManager@mrinalkant.blogspot.com)\n",
+      "0.245%: Nimbus Screen Capture - editable screenshots. (nimbusscreencaptureff@everhelper.me)\n",
+      "0.240%: YouTube High Definition ({7b1bf0b6-a1b9-42b0-b75d-252036438bdc})\n",
+      "0.227%: iMacros for Firefox ({81BF1D23-5F17-408D-AC6B-BD6DF7CAF670})\n",
+      "0.227%: YSlow (yslow@yahoo-inc.com)\n",
+      "0.212%: FoxyProxy Standard (foxyproxy@eric.h.jung)\n",
+      "0.211%: Test Pilot (testpilot@labs.mozilla.com)\n",
+      "0.209%: Classic Theme Restorer (Customize UI) (ClassicThemeRestorer@ArisT2Noia4dev)\n",
+      "0.206%: colorPicker (colorPicker@colorPicker)\n",
+      "0.206%: Firefox OS 2.0 Simulator (fxos_2_0_simulator@mozilla.org)\n",
+      "0.204%: Module de blocage des sites Internet dangereux (content_blocker_663BE84DBCC949E88C7600F63CA7F098@kaspersky.com)\n",
+      "0.203%: AdBlock for YouTube (jid1-q4sG8pYhq8KGHs@jetpack)\n",
+      "0.203%: Virtuellt tangentbord (virtual_keyboard_07402848C2F6470194F131B0F3DE025E@kaspersky.com)\n",
+      "0.200%: Disconnect (2.0@disconnect.me)\n",
+      "0.196%: Sicherer Zahlungsverkehr (online_banking@kaspersky.com)\n",
+      "0.192%: Easy Youtube Video Downloader Express ({b9acf540-acba-11e1-8ccb-001fd0e08bd4})\n",
+      "0.191%: YouTube Flash Video Player ({f3bd3dd2-2888-44c5-91a2-2caeb33fb898})\n",
+      "0.188%: Multifox (multifox@hultmann)\n",
+      "0.187%: jid1BYcQOfYfmBMd9Ajetpack (jid1-BYcQOfYfmBMd9A@jetpack)\n",
+      "0.184%: Klawiatura wirtualna (virtual_keyboard@kaspersky.com)\n",
+      "0.182%: YouTube Unblocker (youtubeunblocker@unblocker.yt)\n",
+      "0.180%: Blokowanie banerw (anti_banner@kaspersky.com)\n",
+      "0.180%: Reload Plus (reloadplus@blackwind)\n",
+      "0.180%: BetterPrivacy ({d40f5e7b-d2cf-4856-b441-cc613eeffbe3})\n",
+      "0.179%: Tamper Data ({9c51bd27-6ed8-4000-a2bf-36cb95c0c947})\n",
+      "0.177%: Screengrab  (fix version) ({02450914-cdd9-410f-b1da-db004e18c671})\n",
+      "0.177%: En-ttes HTTP en direct ({8f8fe09b-0bd3-4470-bc1b-8cad42b8203a})\n",
+      "0.172%: Autofill (firefox-autofill@googlegroups.com)\n",
+      "0.170%: Firefox OS 3.0 Simulator (fxos_3_0_simulator@mozilla.org)\n",
+      "0.170%: Cookies Manager+ ({bb6bc1bb-f824-4702-90cd-35e2fb24f25d})\n",
+      "0.165%: Empty Cache Button ({4cc4a13b-94a6-7568-370d-5f9de54a9c7f})\n",
+      "0.164%: Ant Video Downloader (anttoolbar@ant.com)\n",
+      "0.164%: Firefox OS 2.2 Simulator (fxos_2_2_simulator@mozilla.org)\n",
+      "0.163%: Speed Dial [FVD] - New Tab Page, Sync... (pavel.sherbakov@gmail.com)\n",
+      "0.161%: Sicherer Zahlungsverkehr (online_banking_08806E753BE44495B44E90AA2513BDC5@kaspersky.com)\n",
+      "0.159%: anonymoX (client@anonymox.net)\n",
+      "0.156%: Show Selected Images ({DEDA1132-B316-11DD-8BC1-4E5D56D89593})\n",
+      "0.155%: ImageBlock (imageblock@hemantvats.com)\n",
+      "0.153%: HttpRequester ({ea4637dc-e014-4c17-9c2c-879322d23268})\n",
+      "0.151%: Easy Screenshot (easyscreenshot@mozillaonline.com)\n",
+      "0.151%: Video Downloader professional (ffext_basicvideoext@startpage24)\n",
+      "0.147%: EPUBReader ({5384767E-00D9-40E9-B72F-9CC39D655D6F})\n",
+      "0.145%: Kaspersky Protection (light_plugin_D772DC8D6FAF43A29B25C4EBAA5AD1DE@kaspersky.com)\n",
+      "0.144%: HTTPS-Everywhere (https-everywhere-eff@eff.org)\n",
+      "0.143%: Bantuan SaveFrom.net (helper@savefrom.net)\n",
+      "0.142%: ImTranslator ({9AA46F4F-4DC7-4c06-97AF-5035170634FE})\n",
+      "0.141%: QuickJava ({E6C1199F-E687-42da-8C24-E7770CC3AE66})\n"
+     ]
+    }
+   ],
+   "source": [
+    "for addon, addon_count in Counter(addon_counts).most_common(100):\n",
+    "    if not addon in whitelisted_addons:\n",
+    "        print \"{:.3f}%: {} ({})\".format(100.0 * addon_count / total_addons, addon_names[addon], addon)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
[Bug 1224518](https://bugzilla.mozilla.org/show_bug.cgi?id=1224518)

This experiment lists the top addons in the Telemetry pings and compares them to the [whitelisted e10s addon list](https://wiki.mozilla.org/Electrolysis/Addons). According to jimm, all addons on that page are "approved".