### PR TITLE
Extract addon whitelist into own file

### DIFF
--- a/aurora/addons/whitelist.py
+++ b/aurora/addons/whitelist.py
@@ -1,0 +1,68 @@
+# Fetched from https://wiki.mozilla.org/Electrolysis/Addons
+# Some entries have been commented out because the addon ID could not be determined.
+ADDON_WHITELIST = {
+    # Broken
+    "YoutubeDownloader@PeterOlayev.com":                "1-Click YouTube Video Downloader",
+    "wrc@avast.com":                                    "Avast Online Security",
+    "abs@avira.com":                                    "Avira Browser Safety",
+    "translator@zoli.bod":                              "Google Translator for Firefox",
+    "firefox@ghostery.com":                             "Ghostery",
+    "{3d7eb24f-2740-49df-8937-200b1cc08f8a}":           "Flashblock",
+    "{635abd67-4fe9-1b23-4f01-e679fa7484c1}":           "Yahoo! Toolbar",
+    "{7affbfae-c4e2-4915-8c0f-00fa3ec610a1}":           "Aol Toolbar",
+    "jid1-F9UJ2thwoAm5gQ@jetpack":                      "Lightbeam",
+    "{1BC9BA34-1EED-42ca-A505-6D2F1A935BBB}":           "IE Tab 2",
+
+    # Somewhat working/uses CPOWs
+    "{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}":           "Adblock Plus",
+    "adblockpopups@jessehakanen.net":                   "Adblock Plus Pop-up Addon",
+    "avg@toolbar":                                      "AVG SafeGuard toolbar",
+    "elemhidehelper@adblockplus.org":                   "Element Hiding Helper for Adblock Plus",
+    "{73a6fe31-595d-460b-a920-fcc0f8843232}":           "NoScript",
+    "{19503e42-ca3c-4c27-b1e2-9cdb2170ee34}":           "FlashGot",
+    "mozilla_cc2@internetdownloadmanager.com":          "IDM CC",
+    "yasearch@yandex.ru":                               "Yandex Elements",
+    "support@lastpass.com":                             "LastPass",
+    "{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}":           "WOT",
+    "artur.dubovoy@gmail.com":                          "Flash Video Downloader - YouTube HD Download [4K]",
+    "onepassword4@agilebits.com":                       "1Password",
+
+    # Totally working
+    "cck2wizard@kaply.com":                             "CCK2",
+    "firebug@software.joehewitt.com":                   "Firebug",
+    "{2b10c1c8-a11f-4bad-fe9c-1c11e82cac42}":           "uBlock",
+    "{46551EC9-40F0-4e47-8E18-8E5CF550CFB8}":           "Stylish",
+    "{dc572301-7619-498c-a57d-39143191b318}":           "Tab Mix Plus",
+    "jid1-YcMV6ngYmQRA2w@jetpack":                      "Pin It button",
+    "{e4f94d1e-2f53-401e-8885-681602c0ddd8}":           "McAfee Security Scan Plus",
+    "https-everywhere@eff.org":                         "HTTPS-Everywhere",
+    "url_advisor@kaspersky.com":                        "Kaspersky URL Advisor",
+    "abb@amazon.com":                                   "Amazon 1Button App for Firefox",
+    "{a7c6cf7f-112c-4500-a7ea-39801a327e5f}":           "FireFTP",
+    "personas@christopher.beard":                       "Personas Plus",
+    "mozsocial.cliqz.com@services.mozilla.org":         "Cliqz",
+    "{6c28e999-e900-4635-a39d-b1ec90ba0c0f}":           "Download Status Bar",
+    "{e4a8a97b-f2ed-450b-b12d-ee082ba24781}":           "Greasemonkey",
+    #                                                   "United Internet Addons",
+    "verticaltabs@mozilla.com":                         "Vertical Tabs",
+    "{b9db16a4-6edc-47ec-a1f4-b86292ed211d}":           "Video DownloadHelper",
+    "foxmarks@kei.com":                                 "Xmarks",
+    "{0545b830-f0aa-4d7e-8820-50a4629a56fe}":           "ColorfulTabs",
+    "{b9bfaf1c-a63f-47cd-8b9a-29526ced9060}":           "Download YouTube Videos as MP4",
+    "{DDC359D1-844A-42a7-9AA1-88A850A938A8}":           "DownThemAll!",
+    "{1018e4d6-728f-4b20-ad56-37578a4de76b}":           "Flagfox",
+    "extension@one-tab.com":                            "OneTab",
+    "feca4b87-3be4-43da-a1b1-137c24220968@jetpack":     "YouTube Video and Audio Downloader",
+
+    # Other
+    "firefox@mega.co.nz":                               "MEGA",
+    #                                                   "Norton Toolbar",
+    "{4ED1F68A-5463-4931-9384-8FFF5ED91D92}":           "McAfee WebAdvisor",
+    "vb@yandex.ru":                                     "Yandex Visual Bookmarks",
+    "{ef4e370e-d9f0-4e00-b93e-a4f274cfdd5a}":           "FoxTab",
+    #                                                   "LogMeIn Remote Access",
+    "{195A3098-0BD5-4e90-AE22-BA1C540AFD1E}":           "Garmin Communicator",
+    #                                                   "IBM CCK",
+    "{fe272bd1-5f76-4ea4-8501-a05d35d823fc}":           "Adblock Edge",
+    "{87F8774F-B485-47E2-A755-A40A8A5E8874}":           "GBBD Banco Santander (Brasil) S.A."
+}


### PR DESCRIPTION
As requested by jimm in [bug 1224518](https://bugzilla.mozilla.org/show_bug.cgi?id=1224518#c12).