### PR TITLE
Add beta 45 analyses

### DIFF
--- a/beta45-withaddons/e10s_top_hang_stacks.ipynb
+++ b/beta45-withaddons/e10s_top_hang_stacks.ipynb
@@ -1,0 +1,1654 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### E10S Experiment Beta 45 (with addons): Top hang stacks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Bug 1222972](https://bugzilla.mozilla.org/show_bug.cgi?id=1222972)\n",
+    "\n",
+    "This analysis compares e10s and non-e10s hang stacks and their frequencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unable to parse whitelist (/home/hadoop/anaconda2/lib/python2.7/site-packages/moztelemetry/bucket-whitelist.json). Assuming all histograms are acceptable.\n",
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ujson as json\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.plotly as py\n",
+    "import IPython\n",
+    "import functools\n",
+    "\n",
+    "from __future__ import division\n",
+    "from moztelemetry.spark import get_pings, get_one_ping_per_client, get_pings_properties\n",
+    "from montecarlino import grouped_permutation_test\n",
+    "\n",
+    "%pylab inline\n",
+    "IPython.core.pylabtools.figsize(16, 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "128"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.defaultParallelism"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Get e10s and non-e10s partitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dataset = sqlContext.read.load(\"s3://telemetry-parquet/e10s-experiment/e10s-beta45-withaddons@experiments.mozilla.org/generationDate=20160201\", \"parquet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many pings do we have in each branch?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "186828"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.filter(dataset[\"experimentBranch\"] == \"experiment\").count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "197241"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.filter(dataset[\"experimentBranch\"] == \"control\").count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sample by cliet ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sampled = dataset.filter(dataset.sampleId <= 20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "80189"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sampled.count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Transform Dataframe to RDD of pings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def row_2_ping(row):\n",
+    "    ping = {\"payload\": {\"threadHangStats\": json.loads(row.threadHangStats)},\n",
+    "            \"e10s\": True if row.experimentBranch == \"experiment\" else False}\n",
+    "    return ping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "subset = sampled.rdd.map(row_2_ping)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Thread activity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def chi2_distance(xs, ys, eps = 1e-10, normalize = True):\n",
+    "    histA = xs.sum(axis=0)\n",
+    "    histB = ys.sum(axis=0)\n",
+    "    \n",
+    "    if normalize:\n",
+    "        histA = histA/histA.sum()\n",
+    "        histB = histB/histB.sum()\n",
+    "    \n",
+    "    d = 0.5 * np.sum([((a - b) ** 2) / (a + b + eps)\n",
+    "        for (a, b) in zip(histA, histB)])\n",
+    "\n",
+    "    return d\n",
+    "\n",
+    "def ignore_below_(min_limit, histogram):\n",
+    "    histogram = histogram.ix[129:].set_value(0, histogram.ix[0: 128].sum()).sort_index()\n",
+    "    histogram = histogram.ix[min_limit:]\n",
+    "    return histogram\n",
+    "\n",
+    "def ignore_below(histograms, min_limit=0):\n",
+    "    return histograms.map(functools.partial(ignore_below_, min_limit))\n",
+    "\n",
+    "def normalize(histograms):\n",
+    "    return histograms.map(lambda h: h/max(h.sum(), 1))\n",
+    "\n",
+    "def compare_histogram(histogram, e10s, none10s):\n",
+    "    pvalue = grouped_permutation_test(chi2_distance, [e10s, none10s], num_samples=100)\n",
+    "    \n",
+    "    eTotal = e10s.sum()\n",
+    "    nTotal = none10s.sum()\n",
+    "        \n",
+    "    eTotal = 100*eTotal/eTotal.sum()\n",
+    "    nTotal = 100*nTotal/nTotal.sum()\n",
+    "        \n",
+    "    fig = plt.figure()\n",
+    "    fig.subplots_adjust(hspace=0.3)\n",
+    "        \n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    ax2 = ax.twinx()\n",
+    "    width = 0.4\n",
+    "    ylim = max(eTotal.max(), nTotal.max())\n",
+    "        \n",
+    "    eTotal.plot(kind=\"bar\", alpha=0.5, color=\"green\", label=\"e10s\", ax=ax, width=width, position=0, ylim=(0, ylim + 1))\n",
+    "    nTotal.plot(kind=\"bar\", alpha=0.5, color=\"blue\", label=\"non e10s\", ax=ax2, width=width, position=1, grid=False, ylim=ax.get_ylim())\n",
+    "        \n",
+    "    ax.legend(ax.get_legend_handles_labels()[0] + ax2.get_legend_handles_labels()[0],\n",
+    "              [\"e10s ({} samples\".format(len(e10s)), \"non e10s ({} samples)\".format(len(none10s))])\n",
+    "\n",
+    "    plt.title(histogram)\n",
+    "    plt.xlabel(histogram)\n",
+    "    plt.ylabel(\"Frequency %\")\n",
+    "    plt.show()\n",
+    "        \n",
+    "    print \"The probability that the distributions for {} are differing by chance is {:.2f}.\".format(histogram, pvalue)\n",
+    "\n",
+    "def compare_histograms(histogram, e10s, none10s, min_limit):\n",
+    "    e10s = ignore_below(e10s, min_limit)\n",
+    "    none10s = ignore_below(none10s, min_limit)\n",
+    "    compare_histogram(histogram + \" (normalized)\", normalize(e10s), normalize(none10s))\n",
+    "    compare_histogram(histogram + \" (absolute)\", e10s, none10s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Manually massage the thread activity histogram into payload/histograms so that\n",
+    "# get_pings_properties will treat is a histogram.\n",
+    "def get_activity(ping):\n",
+    "    for thread in ping[\"payload\"][\"threadHangStats\"]:\n",
+    "        if thread[\"name\"] != \"Gecko\":\n",
+    "            continue\n",
+    "\n",
+    "        values = {str(int(k) + 1): v for k, v in thread[\"activity\"][\"values\"].iteritems()}                                        \n",
+    "        yield {\"e10s\": ping[\"e10s\"], \"payload\": {\"histograms\": {\"GECKO_THREAD_ACTIVITY_MS\": {\"values\": values}}}}\n",
+    "\n",
+    "def compare_thread_activity(pings, name, min_limit=0, normalize=True):\n",
+    "    histograms = json.loads(\"\"\"\n",
+    "    {\n",
+    "      \"GECKO_THREAD_ACTIVITY_MS\": {\n",
+    "        \"expires_in_version\": \"default\",\n",
+    "        \"kind\": \"exponential\",\n",
+    "        \"high\": \"2**24\",\n",
+    "        \"n_buckets\": 26,\n",
+    "        \"description\": \"\"\n",
+    "      }\n",
+    "    }\n",
+    "    \"\"\")\n",
+    "                \n",
+    "    histogram = \"payload/histograms/GECKO_THREAD_ACTIVITY_MS\"\n",
+    "    props = get_pings_properties(pings.flatMap(get_activity), [\"e10s\", histogram], additional_histograms=histograms)\n",
+    "    frame = pd.DataFrame(props.collect())\n",
+    "    \n",
+    "    e10s = frame[frame[\"e10s\"] == True]\n",
+    "    none10s = frame[frame[\"e10s\"] == False]\n",
+    "    \n",
+    "    compare_histograms(histogram, e10s[histogram].dropna(), none10s[histogram].dropna(), min_limit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Parent main thread activity with 64ms and below buckets merged into the 0 bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA8QAAAHZCAYAAABAe/KbAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3XucVXW9//HXBxAFucwggqASKoGieSkl0xQ0UcISilQo\nr8d+5DWtLO+K6Qk1PZJ1NC0V0tJQ07xEylFRO6dSUvGIGuhxvCCgIFeRS/L9/bHWbPYMAzPMDDLb\n/Xo+HvvB3mut73d91xr2fuz3/n7Xd0VKCUmSJEmSyk2rTd0ASZIkSZI2BQOxJEmSJKksGYglSZIk\nSWXJQCxJkiRJKksGYkmSJElSWTIQS5IkSZLKkoFYUsmLiPERcdlGqHdQRLy1nvVVEfGldaw7ICJe\nae42SWo5IuKwiLh3U7ejPhHROyJWR0Sr/PWfIuLYZt7HmIi4LX/ePSJeioi2zbkPSdoYDMSSPglS\n/tjoIqJnUUhe535TSk+llHZuQH2FL5GfBBFxXkT8e/68Y0T8R0S8HhFLI+KNiLgrIgYUbb86X7ek\n6HF20fq+eZn3ImJhREyLiO9FRKs6vuRHRPw8Il6OiB756x9GxIyIWJbv/yf1fUmPiElFbVkZESuK\nXl+/rh9KImJKRJyUPx+Ut21JRCyOiFci4oRa26/32PNtTsi3O6rW8uL6l0TEWxHx+4jYewP+VhER\n/xcR09ex7rsR8b95G9+KiIkRsduGnJ+I+GVETKij/j0iYnlEVFa/ByJi+1rno/b5ubB2yIqIrSLi\n3Yg4dD3HWX2u/lBHG1ZHxONFy4ZFxPMRsSj/P/doRPRez2n8d2Ds+s5zS5RSGppSau7PncJnYUpp\nLvA4MLqZ9yFJzc5ALOmTIj6m/QwFJn1M+2qSiGizCXY7FHgoIjYHHgN2BQ4HOgK7AHcCX65VZveU\nUseix9UAEbET8HfgDWC3lFIFcCTwOaBDcQV5KL4ROBA4MKU0G7gO+H/Asfn2Xwa+BExc3wGklL5c\n3Rbgt8CVRW07dX1FqfkDyay8TCfge8CvIqJvQ469yPHA+8BxdexvVlE79wVeAZ6KiIPXd3xFDgS2\nBnaoI0j/DPgucAZQCfQF7gMO38DzMx74ekS0r7X8WOCBlNKC6gUppbdSSh2K6oaa5+dyYBZwcVE9\n44AHU0qP1HOs7wH7RkSXomXHAzPI/2YR0QeYAHwvpdQZ2AH4T+CjuiqMiH2ATimlp+vZ9wbbRO/d\n5vZb4DubuhGSVB8DsaSPTWRDjM+NiOkR8X5E3JIHJyKiIiIezHt73o+IByJi23zdkRExtVZd34+I\n+9axn/8XETMjYn5E/DEiehSt+1lEvJn3AE2NiC8WrWsX2fDr9/Nes33qqH4o8Kei13tF1mu5MCLu\nLDqeGr2IEXFORLwda3oLD46IIcB5wNF5D9hz+bY9I+L+vP0zI+Lbtdo4IW/jSxHxo1r7qcqXvQAs\niYjW+Tl/Nd/39IgYXrT9CRHx35H15C6IiNci4gv58jcjYm5EHFe0/dC8jsX58fygaF11cPorWeDZ\nFhieUnopZZallO5JKV1a19+tDpcCf0kpnZ33OJFSmpFSOialtLhouzbArcBngUEppfci4tPAKcA3\nU0p/TymtTim9BIwAhkTEQQ1sAzTDjy0ppUlkwfYzDd5pxKfIQuv/Aw6LiO7rqX9WSukS4NfAlQ3c\nxfHAH8l+4Dm+aL+fBk4FRqaUpqSUVqWUPkwp/S6lVFfd6zw/KaW/kYXYEUX1twZGAb9pYDuLfRs4\nNe/dPQw4mOzHhvqsJAv0I4vacBRZaKtu/57A6ymlx/O2L00p/SGltK7LJr4MTClekPc4fyeyUQkL\nIuIXResisl7uqvx9NSEiOuXrqkc7/FtEvAE8GhHHb+B78/CIeC7/bHszIi5Z18mImqMZpkXNUQqr\nI+LAfN2+EfE/+f6fj4iBRXXsEBFP5J8FjwBda+3maWDHiNh+Xe2QpJbAQCzp4/ZN4FBgJ7LwdGG+\nvBVwM9Arf3wIVH+ZvJ+sF6t4CPKxZL05NUTWO/YTsp7EHmS9i3cWbfI0sAdZr9fvgLtizRDMS8h6\nhXYEDiMLCYUev4jYDDgAmFy9KN/PYXm53YET6mhTP+A0YO+8t/BQoCql9Oe8rXfmPWB75UXuBN7M\n2/8N4CdFAe6S/PzsAAwGjmHtYdsjyb6sV6SUPgJeBb6Y7/tS4PZa4WoAMA3okp+T35P1wu6U1/+L\nWNPDdzMwOq9rV7Je4GqHAf+VUkrAIcCfU0of1j4fdVhXoPoScHcDyv8O+DRwcFGP45eAt1JKNX5I\nSSm9DfyN7Nx9LCIb3n0EWWB4tfbq9RQ9DngmpXQv8DLwrQbs7l7gsxHRrp42tScLqbeThcKRsaZX\nss5z1wS/oWYP9yHAZtT8YalBUkpvkPUQ3wrcAJySUlrUwOK3FbXjMOBF4J2i9c8CO+cBdFBEdKhd\nQS27Af+sY/nhwN5knwdH5cEd4ESyz5RBZJ8xHVjzGVftQGDnvH3Bhr03lwLH5L3bhwOnRMSwdbS9\nMJohpbRHUa/8D8hGGjwb2Q+SDwI/TilVAmcD90TEVnkdvwOeAbYCLqPW52VK6V9k/9/3XEcbJKlF\nMBBL+jgl4Bd5b9YCsuvvRgGklN5PKd2bUlqeUlpKFhQH5utWkH0RPAYgInYFPkX2Za24bshCw80p\npedTSivJemC/EBG98rp+m1JakPcY/gewOdAvL3sk8O8ppYV5cPoZNQPLgcC0lNIHRfu8LqU0Jz+e\nB6j7y99H+X52jYjNUkpvppT+L18XxfvIe1P2A85JKa1MKU0j6/Wr/iJ/JPCTlNKilNKsOtpY3aZZ\n+XkjpXR3SmlO/nwiMBP4fFGZ11NKE/IgOxHYjuxL8KqU0mSy3rU++bYr8+PolLfhuaJ6DmdNyNkK\nmFN0XHvmvUyLYu3Jxp7N11U/BhfVMbuO81nbIcDdtXqNuxbvv5bZed1N0bNWmxcAX6xrG2AZ8Aey\nobjTam2zrmOH7G/+u/z576h72HRt75D9f6ioZ7uvA8uBR4CHyALqV/J1Nf52zeB2YGBE9MxfHwf8\nNv+xZoOllH5B9v/wuZTS/RtQ7q9Al8iGrR9HrR/U8vfkILKRDROB9yLi1ojYch1VVgBL6lh+RUpp\ncd6z/DjZD3CQfTZdk1Kqyj9DziP7IaL4u9iYvDd+ef66we/NlNITKaXp+fP/JfthbSANFNlomcuA\nI/LP4GOAP+U/3JFS+i9gKnB4/nm6N3BR3panyD7/av/AswTo3NA2SNKmYCCW9HErHn74JtATsh6r\niLgxH064CHgC6BwR1V+wJpD1LkPWO/z7lNKqOuqv7hUGIP/iOZ/sSy4RcXZkQ40X5mGlM2uG+vWs\no33FhpKFh2LFweFDal3bmrfhVeAsYAwwNyLuiKJh3LX0BN4vCt3V7ehZtL64jW/XUUeNIZ4RcVw+\nlLI6uO1GzUA4t9YxkFJ6bx3HNYLsPFTlwy73zffRirxXON9uflGbyX+gqCQLYpvXau9eKaXKosfk\nuupYj68Al0TEiUXL5pH9X6hLz3x9U7xTq82VwF/q2gboRHY9c10zktd57BGxP9Cb7IcggDuAz0TE\nHnXUUWxbsh9FFtaz3fHAXfkPQyvIAnv1sOn5rPvcbbCU0pvAk8Cxea/rMBo3XLrYy8Bak4E1wG1k\n10UPIutNrxHg8uH1R6eUupGNBjkQuGAddS0g+9vWVvyZsIw1750an01k7+s2QPFojdrDsxv83oyI\nz0fE45FddrKQ7PrdBv3wk/8Q93vguPzzCrIfHY+s9aPP/sA2ZO+hBbVGgLzB2jpS//9FSdqkDMSS\nPm69aj2flT//AdkQ6gH5kL+BFPWeppT+DqzMr20bRfbFti7vkAUJAPLena2AWRFxAPBD4MiUUkUe\nVhax5kvx7DraV+zLNGKYZ97+O1JKB5B9yUysuc6z9nDnd8h6sYqDdfF5mg0UX5NX1/V5xcO8PwXc\nRDZku0t+zC/SyOtiU0pTU0rDySZjuo81E1TtA7yRUpqfv34UODTWnkxpQ/b7XxRde7oe/wN8FfhZ\nRIwq2v/2kU18tGbn2Rf/z+frPxb5SIVzyALtuoaw1nY82bl6PiJmkw3zrl6+Pl8D/rG+oeoRsR3Z\ntbfHRMTsvP4RwNB8OOyjwHYR8bkGtrUhJpD9kDWCrNezeGRBY2eIb8z/4dvJri1/qKgXtk75kPF7\nyX5AqssLZJ9ZDVXjs4nsff0vaobepsyW/zuy9+R2KZuA7pc04HtePrz+PuDalNLDRaveBG6r9YNN\nx5TSVWSfQ5W13t/Vn23V9bYh672uPSpCkloUA7Gkj1OQTYizbWSzvV7Amh6wDmS9HYvydXVNCPMb\nsmvuVqaU/qdWvdVfju8AToxs0p3NyYZe/y3vpepI9gV0XkS0jYiLqdnDMxE4L7IJvrYj60nKdhCx\nA7B5SqmuawbXf9DZrYMOztuzgmyoavVw0TlA7+qe8HyY5f8AYyNi84jYHfg3si/ytdu4LXA66/8S\nvWW+fh7QKu9FXdcX/PqOY7OI+FZEdM6Huy4pOo6h1BzC/huyL833RsSukU3utQXZMMva7V1XsLkE\n2C8irqq+5jki+kR2i54aPXMppSfJep9vioivp5RmkgWC3+Y9Z63zofb3AJNTSo/RMM0ye3k+muEa\nas6QXGf9+Xk6imwyrT2KHmcA34xsQqji7SN/T10CnAScX09zjiW7TrRvUd19yUYbjMrP3fXAHREx\nMH+vbBERIyPinPravw73kAXAMWQzTzemjqaWIaX0Ouvo9Y2IL0bEtyNi6/z1zmQ/tPx1HdX9ifqH\nJNf+bPpeZBNodWDN/AGrN/xI6tSBrNd2ZWS3NvsmDQvYtwAvp7VnOL8d+GpEHFr9/o3s2uptU3Yt\n91Tg0vxz4YusGXJfbQDZXAnrvJe7JLUEBmJJH6dE1ovxCPAa2bWsl+frxgHtyILb/5DNfFv7y9xt\nZBM53V5refEEMY8CF5F9AX+HbPKpkfl2f84fM4AqsgBePCz6UrJhf6/n2/2mqA2Hs/Zw6bqOL9V6\nDdkQ4bFkt36ZTTZE+7x83V35v/NjzUzao8h6kt4hG8p6cVGA+zFZcHmd7DzeRXYdYd0NymZWvobs\nS/0csjBcPLS3rnspr+9L9DHA6/mw9tGsmeipxuzb+TDcg4CXyM7bIrIQ9jmysFes9iy3/5HX8X/A\nF/JzMT0fBno32UQ+S2u3Nb/G8WhgQkQcTvZjwa/J/r8sIfs/9RgN63UuVEvd56MhQaP2NrcAvfK2\nVavr2IcBHwC/SSm9W/0gm0iqDdmES4nsGuUl+bE9TfbeGJifh/U5Dri+uO6UzeL9y3wdKaXvkv34\n9J9kQ4NfzdtV+5rdBp2flNIysvfktmSTeG1wHQ0ss77tq9vyP9XX1NeqZwFwBPC/+XmdRPb+u6rO\nCrNe7kVRdF/tOtpUXP8tZJ9hTwL/Rzac+oxa266r7Lq2KXYq8OOIWEz2Gfj7WuvXVfZoYHit/4f7\np2wehWFkP7C8S/ZZ+QPWfHf8Jtloi/fJfuipPcnht8gmPpOkFi2yeRokaeOLiNeBkzagd652+XZk\nwwv3Sim91qyNq3/fDwE/r55gpqWIiFOAo1JKG3IboeZuQ3fg2ZTStpuqDdKmENkkaKemlL62qdvS\nkkREN7JbUu2ZXzIgSS2WPcSSSskpwNMfdxjOTaHWPUc3hYjYJiL2j+xWPv2A75Nd57gpdcrbIZWV\nlNJkw/Da8lEH/Q3DkkpBm/o3kaRNLyKqyIb8Dd8U+08p/XRT7LcObcmGtu5ANnvrHWTXe24y+TWn\nMzdlGxojIqaz9sRpkN1n+Y6Puz3NKZ9Arq4J4FLK7iH9iRIR57PmMoRiT6aUDq9juSRJgEOmJUmS\nJEllar1DpiPiloiYGxH/W7SsS0RMjogZEfFIRFQUrTsvImZGxCsRcejGbLgkSZIkqeVryblyvT3E\n+ZCrpWQzXX4mX3YVMC+ldFV++4XKlNK5EdGfbPbYfchmkfwvoG/t2wlEhF3SkiRJkvQJllIq3CJv\nY+TK5rLeHuKU0lNktyEodgRrptafwJrr+YYBd6SUVqWUqshu0TCAOqSUNunjkksu2eRt8Dg8jpb4\n+CQcg8fR8h4eR8t6eBwt6/FJOI5PwjF4HC3v4XG0rMeGHsfHlSubQ2Nmme6esvsVQnb7k+75855k\n98as9jZZopckSZIkqViLyJVNuu1SyuL/+oZAOzxakiRJkrROmzJXNua2S3MjYpuU0pyI6AG8my+f\nBWxftN12+bK1jBkzpvB80KBBDBo0aL07POusMSxc2IiWrsNf/vogVQurmq2+ii0qGHfFuGarr6Hq\nO2+lwuNoOT4JxwAeR0vjcbQsHkfL8kk4jk/CMYDH0dJ4HC1LfccxZcoUpkyZsqHVNjlXNod6b7sU\nEb2BB1LNi5/np5SujIhzgYpU8+LnAay5+LlPqrWDiKi9qF4nnDCG3r3HbFCZ9bl94iEcc/0Xm62+\nqvuqGD9ufLPVJ0mSJEmlKiJIRZNq5ct604y5srmst4c4Iu4ABgJdI+It4GLgCmBiRJwEVAFHAaSU\nXoqIicBLwL+AUzdWoyVJkqSNJSLq30gSQJ2TaNXWknPlegNxSmnUOlYdso7tfwL8pKmNkiRJkjYl\n+3Wk+jX0x6OWnCubNKmWJEmSJEmlykAsSZIkSSpLBmJJkiRJUlkyEEuSJEnaYKNGjeKPf/zjpm5G\nyamqqqJVq1asXr16UzdFNO4+xJIkSVJZOevcs1i4fOFGq79iiwrGXTGuyfW8+OKL/OAHP+DZZ59l\n/vz5a4Wu999/n5NOOonJkyfTtWtXxo4dy6hR65rvaN1eeOEFXnjhBe644w4AHn/8cc4880zeeust\nWrduzYEHHsgvfvELevbsWdjvKaecwqOPPkpEcNhhh3HDDTfQsWNHAB544AHOO+883njjDXbffXd+\n/etfs8suuwAwfvx4TjrpJNq3b1/Y/0MPPcSBBx4IZAHz1FNP5W9/+xubb7453/jGNxg3bhytW7fe\n8BOosmMgliRJkuqxcPlCeg/vvdHqr7qvqlnqadu2LSNHjuS0005j+PDha60/7bTT2GKLLXj33Xd5\n7rnnOPzww9ljjz3o37//Bu3nxhtv5Jhjjim83nXXXZk0aRLbbrstq1at4sILL+SUU04p9CBfeOGF\nLFq0iKqqKlavXs2IESMYM2YM11xzDTNnzuSYY45h0qRJ7Lvvvlx11VUcccQRvPLKK4VQu//++/Pk\nk0/W2ZZTTz2V7t27M2fOHBYsWMDgwYO5/vrrOeOMMzbomFSeHDItSZIklZB33nmHESNG0K1bN3bc\ncUd+/vOfF9b17duXE088sc6A+8EHH/CHP/yByy67jPbt27P//vszbNgwbrvtNgDmzZvHV77yFSor\nK9lqq6048MAD13n7qT//+c8MHDiw8Lpbt25su+22AKxevZpWrVrx2muvFdZXVVUxfPhwOnToQKdO\nnRg+fDjTp08H4OGHH+aAAw5gv/32o1WrVpxzzjnMmjWrRgBe322wqqqqOProo2nbti3du3dnyJAh\nhbpre/XVVxk4cCAVFRVsvfXWjBw5srDuzDPPpFevXnTu3Jm9996bv/zlL4V1Y8aM4cgjj+TYY4+l\nU6dO7L777sycOZOxY8fSvXt3evXqxeTJkwvbDxo0iPPOO4/Pf/7zdO7cmeHDh7NgwYI627Ro0SJO\nOukkevbsyXbbbcdFF11U6NlfX3vVPAzEkiRJUolYvXo1X/3qV9lrr7145513ePTRRxk3bhyPPPJI\nvWVnzJhBmzZt6NOnT2HZHnvsUQiP11xzDdtvvz3z5s3j3XffZezYsXXeZ/aDDz7g9ddfp1+/fjWW\nv/nmm1RWVtK+fXuuueYafvSjHxXWnXbaaTzwwAMsXLiQBQsWcM899zB06FAgu5dtceBdvXo1KSVe\nfPHFwrLnnnuOrbfemn79+nH55Zfz0UcfFdadddZZ3HnnnXz44YfMmjWLSZMm8eUvf7nOc3DRRRcx\nZMgQFi5cyKxZs/jud79bWDdgwACmTZvGggUL+OY3v8mRRx7JypUrC+sffPBBjjvuOBYsWMBee+3F\nYYcdBmQ/UFx88cV85zvfqbGv2267jVtvvZXZs2fTpk2bGvsqdsIJJ9C2bVtee+01nnvuOR555BF+\n/etf19teNQ8DsSRJklQinnnmGebNm8eFF15ImzZt2GGHHfj2t7/NnXfeWW/ZpUuX0qlTpxrLOnbs\nyJIlS4BsuPXs2bOpqqqidevW7L///nXWs3DhwkLZYr169WLBggXMmzePyy+/vEZg3muvvVi5ciVb\nbbUVXbt2ZbPNNuOUU04B4JBDDuGJJ57giSeeYOXKlfzkJz9h5cqVLFu2DICBAwcyffp03nvvPe65\n5x7uuOMOfvrTnxbqPuCAA3jxxRfp1KkT22+/Pfvssw/Dhg2rs+1t27alqqqKWbNm0bZtW/bbb7/C\num9961tUVlbSqlUrvv/977NixQr++c9/FtYfeOCBDB48mNatW/ONb3yD9957j3PPPZfWrVtz9NFH\nU1VVxeLFi4Es5B933HH079+f9u3bc9lllzFx4sS1errnzp3LpEmTuPbaa2nXrh1bb711IeDX1141\nDwOxJEmSVCLeeOMN3nnnHSorKwuPsWPH8u6779ZbtkOHDoXAVm3RokWFYPvDH/6QPn36cOihh7LT\nTjtx5ZVX1llPRUUFQCFI11ZZWcnxxx/PsGHDCkN/jzrqKPr168fSpUtZvHgxO+64Y+Ea5H79+jFh\nwgROP/10evbsyfz58+nfvz/bbbcdADvssAOf+tSnANhtt924+OKLufvuu4GsN3nIkCGMGDGCZcuW\nMW/ePN5//33OOeecOtt21VVXkVJiwIAB7Lbbbtx6662FdVdffTX9+/enoqKCyspKFi1axLx58wrr\nu3XrVnjerl07unbtWuhBb9euHZD96FBt++23Lzzv1asXq1atqlEfZH/PVatW0aNHj8Lf8+STT+a9\n996rt71qHk6qJUmSJJWIXr16scMOOzBjxowNLtu3b1/+9a9/8eqrrxaGTU+bNo3ddtsNyALz1Vdf\nzdVXX8306dM5+OCD2WeffTj44INr1LPllluy00478c9//nOdPZarVq3i3XffZfHixVRUVDBt2jRu\nuOGGQnD8zne+wwEHHFDYfsSIEYwYMQLIeqBvvvlm9tlnn3UeS3VP6/vvv89bb73F6aefzmabbUaX\nLl044YQTuOiii+oM9N27d+emm24C4L//+7855JBDGDhwILNmzeKnP/0pjz32GLvuuisAXbp0We+1\ny/V58803azzfbLPN6Nq1Kx988EFh+fbbb8/mm2/O/PnzadVq7b7KdbV3xx13bHS7VJM9xJIkSVKJ\nGDBgAB07duSqq67iww8/5KOPPuLFF19k6tSphW2WL19euPZ1xYoVrFixAsiC7Ne//nUuvvhili1b\nxl/+8hceeOABjj32WCC7ldGrr75KSolOnTrRunXrdd66aOjQoTzxxBOF1/feey8zZsxg9erVvPfe\ne3z/+9/ns5/9bKE3eZ999uFXv/oVy5cv58MPP+Smm25ijz32KJT/xz/+wUcffcR7773H6NGjGTZs\nGH379gVg0qRJzJ07F4BXXnmFyy+/vDCDdteuXdlhhx244YYb+Oijj1i4cCETJkyoUXexu+66i7ff\nfhvIerojglatWrFkyRLatGlD165dWblyJT/+8Y/X6k3fECklbr/9dl5++WWWLVvGxRdfzJFHHrnW\nNdk9evTg0EMP5fvf/z5Llixh9erVvPbaa4UJxdbVXjUfz6YkSZJUIlq1asWDDz7I888/z4477sjW\nW2/N6NGjC+GtqqqK9u3bs9tuuxERtGvXrnA/X4Drr7+eDz/8kG7dunHMMcfwy1/+srB+5syZDB48\nmI4dO7Lffvtx2mmn1ZhJutjo0aP57W9/W3g9a9YshgwZUpiBuU2bNtx7772F9bfccgtVVVVst912\nbLfddlRVVTFhwoTC+rPOOovKykp23nlnttpqK371q18V1j322GPssccedOjQgcMPP5wRI0Zw/vnn\nF9b/4Q9/YNKkSWy99dZ8+tOfZvPNN+faa6+ts91Tp05l3333pWPHjgwbNozrrruO3r17M2TIEIYM\nGULfvn3p3bs37dq1o1evXoVyEbFWmF3f64jg2GOP5YQTTqBHjx6sXLmS6667rs5tf/Ob37By5Ur6\n9+9Ply5dOPLII5kzZ85626vmE00ZBtCoHUakDd3nCSeMoXfvMc3WhtsnHsIx13+x2eqruq+K8ePG\nN1t9kiRJ2nRqz3oMcNa5Z7Fw+cKNts+KLSoYd8W4jVb/xvCtb32Lo446ap0TWJWzgw46iGOPPZZ/\n+7d/29RN2ajqeq8ULV97ivIWyGuIJUmSpHqUWlj9OBT3EGttH3fHoxrHIdOSJEmS1MzquoezWh57\niCVJkiSpGT3++OObuglqIHuIJUmSJEllyUAsSZIkSSpLBmJJkiRJUlkyEEuSJEmSypKBWJIkSZJU\nlgzEkiRJklqshx9+mK997WubuhkladCgQdx8881NquPss8/ml7/8ZTO1qOXxtkuSJElSPc46awwL\nF268+isqYNy4MRtvBxvB6NGjefLJJ5k5cya33HILxx9/fI311157LVdddRXLli3jG9/4BjfccANt\n27bd4P1ccMEFXH/99Wstf+KJJzjooIO44IILuOyyywCYM2cOo0eP5h//+AezZ8+mqqqKXr16Fcqc\nffbZ3H///cyZM4dtt92W888/n2OPPbZBx/Tiiy/ygx/8gGeffZb58+ezevXqDT6Wj1tENPl+yGef\nfTYDBgzgpJNOYrPNNmumlrUcBmJJkiSpHgsXQu/eYzZa/VVVG6/ujWXPPfdk5MiRnHPOOWuFrocf\nfpgrr7ySxx9/nB49evC1r32NSy65hLFjx27QPp555hkWL17MgAEDaixftWoVZ555Jvvuu2+Nfbdq\n1YqhQ4dy/vnns99++61VX4cOHXjwwQfp27cvTz/9NEOGDKFPnz584QtfqPeY2rZty8iRIznttNMY\nPnz4Bh0UpMOwAAAgAElEQVRHKdtmm23Yeeeduf/++xkxYsSmbk6zc8i0JEmSVEJ69+7NNddcwx57\n7EFFRQUjR45kxYoVhfW/+tWv+PSnP81WW23FsGHDmD17dmFdq1atuPHGG+nbty+VlZWcfvrp69xP\nSokrrriCPn360LVrV44++mgWLFhQWH/qqady8MEHs8UWW6xVdsKECXz7299ml112oaKigosvvpjx\n48cX1l955ZVst912dOrUiZ133pnHHnuszjZMmjSJQYMGrbX8mmuuYciQIfTr14+UUmF5t27dOPnk\nk9l7773rrG/MmDH07dsXgAEDBnDAAQfw17/+tUHH1LdvX0488UT69+9fZ921fe9736N79+507tyZ\n3XffnenTpwPw0EMPsddee9G5c2d69erFpZdeWihTVVVFq1atGD9+PL169aJLly7ceOONPPPMM+y+\n++5UVlZyxhlnFLYfP348+++/P2eccQYVFRXssssu6zyXALfccgv9+/enS5cuDBkyhDfffLPe9kI2\n9Pqhhx5q0HGXGgOxJEmSVEIigrvuuouHH36Y119/nRdeeKEQNh977DHOP/987rrrLmbPns2nPvUp\nRo4cWaP8Qw89xNSpU3nhhReYOHEiDz/8cJ37ue6667j//vt58sknmT17NpWVlZx22mkNauNLL73E\nHnvsUXi9++67M3fuXBYsWMA///lP/vM//5OpU6eyePFiHnnkEXr37l1nPS+++CL9+vWrseyNN97g\n1ltv5aKLLqoRhjfUhx9+yDPPPMNuu+3W6DrW5eGHH+app55i5syZLFq0iLvuuoutttoKyHqpb7/9\ndhYtWsRDDz3EDTfcwB//+Mca5Z9++mleffVVfv/733PmmWcyduxYHnvsMaZPn87EiRN58skna2zb\np08f5s+fz6WXXsrXv/51FtYxvv+Pf/wjY8eO5d5772XevHkccMABjBo1qt72Auy8885Mmzat2c9T\nS2AgliRJkkrMd7/7XbbZZhsqKyv56le/yvPPPw/Ab3/7W0466ST23HNP2rZty9ixY/nrX/9aoyfw\n3HPPpVOnTmy//fYcdNBBhbK13XjjjVx++eX07NmTzTbbjEsuuYS77767QdfOLl26lM6dOxded+rU\nCYAlS5bQunVrVqxYwfTp01m1ahW9evVixx13rLOehQsX0rFjx7WO/fLLL2fLLbds0jWyJ598Mnvu\nuSeHHnpoo8qvT9u2bVmyZAkvv/wyq1evpl+/fmyzzTYADBw4kF133RWAz3zmM4wcOZInnniiRvmL\nLrqItm3bMnjwYDp06MCoUaPo2rUrPXv25IADDuC5554rbNutWzfOPPNMWrduzVFHHUW/fv148MEH\n12rTL3/5S8477zz69etHq1atOO+883j++ed5880319tegI4dO9YZsj8JDMSSJElSiSkOK+3ateOD\nDz4AKPQKV9tyyy3ZaqutmDVrVp1l27dvz9KlS+vcR1VVFV/72teorKyksrKS/v3706ZNG+bOnVtv\n+zp06MDixYsLrxctWgRkwapPnz6MGzeOMWPG0L17d0aNGlVjWHexysrKGvU88MADLF26lCOPPBLI\nhnU3ppf4hz/8IS+99BITJ07c4LINcdBBB3H66adz2mmn0b17d77zne+wZMkSAP7+979z0EEH0a1b\nNyoqKrjxxhuZP39+jfLdu3cvPG/Xrt1ar6v/3gDbbrttjbKf+tSn6jyfb7zxBmeeeWbh71ndA/zO\nO++st72Q/ZBRUVHRhDPSchmIJUmSpE+Inj17UlVVVXj9wQcfMH/+/LVCU0P06tWLP//5zyxYsKDw\nWLZsGT169Ki37K677lqj53natGl0796dyspKAEaNGsVTTz3FG2+8QURwzjnn1FnP7rvvzowZMwqv\nH3vsMaZOnUqPHj3o0aMHEydOZNy4cRt0W6ZLLrmEhx9+mEceeYQOHTo0uNyGOuOMM5g6dSovvfQS\nM2bM4Kc//SkA3/zmNxk+fDhvv/02Cxcu5OSTT27SjNXFP3ZAFnx79uy51na9evXipptuqvH3/OCD\nD9h3333X216Al19+mT333LPRbWzJDMSSJElSiavuJR01ahS33nor06ZNY8WKFZx//vnsu+++NW49\nVFe5upx88smcf/75heHW7733Hvfff39h/apVq1i+fDmrV69m5cqVLF++vFDfcccdx80338zLL7/M\nggULuOyyyzjxxBMBmDFjBo899hgrVqxg8803Z4sttqB169Z1tmHo0KE1hhNfdtllzJw5k2nTpvH8\n889zxBFHMHr0aG699dbCNsuXL2f58uVrPQcYO3Ysd9xxB5MnTy6E82LrO6bq+lauXAnAihUrakxm\nVmzq1Kn8/e9/Z9WqVbRv377GMS5dupTKykratm3L008/ze9+97sNHvZd3KZ3332X6667jlWrVnHX\nXXfxyiuvMHTo0LXKnHzyyfzkJz/hpZdeAihcK1xfeyG7xdWXv/zlDWpjqTAQS5IkSSWs+DraL33p\nS1x22WWMGDGCnj178vrrr3PnnXfW2HZdZWs788wzOeKIIzj00EPp1KkTX/jCF3j66acL6wcPHkz7\n9u3529/+xujRo2nfvj1PPfUUAIcddhg/+tGPOOigg+jduzc77bRTYTblFStWcN5557H11lvTo0cP\n5s2bt87bMVXPxly93w4dOtCtWze6detG9+7dadeuHVtuuWWN4bzt27enU6dORAQ777wzW265ZWHd\nBRdcwFtvvUWfPn3o2LEjHTt25IorrmjQMVVVVdG+fXt22203IoJ27dqxyy671NnuxYsXM3r0aLp0\n6ULv3r3p2rUrP/zhDwG4/vrrufjii+nUqROXXXYZRx999Fp/k/oUb/P5z3+emTNnsvXWW3PRRRdx\nzz331Bn2hw8fzjnnnMPIkSPp3Lkzn/nMZwoTqq2vvbNnz+bll1/+xN5qKpoyM1ujdhiRNnSfJ5ww\nplnv+3b7xEM45vovNlt9VfdVMX7c+GarT5IkSZtORKzVc3rWWWPYmHMKVVTAuHFjNt4OStjkyZO5\n/vrruffeezd1U1qc8ePHc/PNNxdC+8Zw9tln06dPH04++eS11tX1Xila3rjZzj5mbTZ1AyRJkqSW\nzrC66QwePJjBgwdv6maUrauvvnpTN2Gjcsi0JEmSJJWgptx2ShkDsSRJkiSVoOOPP54nn3xyUzej\npBmIJUmSJEllyUAsSZIkSSpLBmJJkiRJUlkyEEuSJEmSypK3XZIkSZJqceZeqTwYiCVJkqQiKaVN\n3QRJHxOHTEuSJEmSypKBWJIkSZJUlgzEkiRJkqSyZCCWJEmSJJUlA7EkSZIkqSwZiCVJkiRJZclA\nLEmSJEkqSwZiSZIkSVJZMhBLkiRJksqSgViSJEmSVJYMxJIkSZKksmQgliRJkiSVJQOxJEmSJKks\nGYglSZIkSWXJQCxJkiRJKksGYkmSJElSWTIQS5IkSZLKkoFYkiRJklSWDMSSJEmSpLJkIJYkSZIk\nlSUDsSRJkiSpLBmIJUmSJEllyUAsSZIkSSpLBmJJkiRJUlkyEEuSJEmSypKBWJIkSZJUlhodiCPi\nexHxYkT8b0T8LiI2j4guETE5ImZExCMRUdGcjZUkSZIklZ6Wmh8bFYgjYlvgDOBzKaXPAK2BkcC5\nwOSUUl/g0fy1JEmSJKlMteT82JQh022A9hHRBmgPvAMcAUzI108AhjeteZIkSZKkT4AWmR8bFYhT\nSrOAa4A3yQ5kYUppMtA9pTQ332wu0L1ZWilJkiRJKkktOT82dsh0JVma7w30BDpExDHF26SUEpCa\n2kBJkiRJUulqyfmxTSPLHQK8nlKaDxARfwC+AMyJiG1SSnMiogfwbl2Fx4wZU3g+aNAgBg0a1Mhm\nSJIkSZI2pSlTpjBlypT1bdKk/LgxNTYQvwHsGxHtgOVkB/g08AFwPHBl/u99dRUuDsSSJEmSpNJV\nu5Pz0ksvrb1Jk/LjxtSoQJxSejoi7gaeBf6V/3sT0BGYGBEnAVXAUc3UTkmSJElSCWrJ+bGxPcSk\nlMYAY2otfp8s7UuSJEmSBLTc/NiU2y5JkiRJklSyDMSSJEmSpLJkIJYkSZIklSUDsSRJkiSpLBmI\nJUmSJEllyUAsSZIkSSpLBmJJkiRJUlkyEEuSJEmSypKBWJIkSZJUlgzEkiRJkqSyZCCWJEmSJJUl\nA7EkSZIkqSwZiCVJkiRJZclALEmSJEkqSwZiSZIkSVJZMhBLkiRJksqSgViSJEmSVJYMxJIkSZKk\nsmQgliRJkiSVJQOxJEmSJKksGYglSZIkSWXJQCxJkiRJKksGYkmSJElSWTIQS5IkSZLKkoFYkiRJ\nklSWDMSSJEmSpLJkIJYkSZIklSUDsSRJkiSpLBmIJUmSJEllyUAsSZIkSSpLBmJJkiRJUlkyEEuS\nJEmSypKBWJIkSZJUlgzEkiRJkqSyZCCWJEmSJJUlA7EkSZIkqSwZiCVJkiRJZclALEmSJEkqSwZi\nSZIkSVJZMhBLkiRJksqSgViSJEmSVJYMxJIkSZKksmQgliRJkiSVJQOxJEmSJKksGYglSZIkSWXJ\nQCxJkiRJKksGYkmSJElSWTIQS5IkSZLKkoFYkiRJklSWDMSSJEmSpLJkIJYkSZIklSUDsSRJkiSp\nLBmIJUmSJEllyUAsSZIkSSpLBmJJkiRJUlkyEEuSJEmSypKBWJIkSZJUlgzEkiRJkqSyZCCWJEmS\nJJUlA7EkSZIkqSwZiCVJkiRJZclALEmSJEkqSwZiSZIkSVJZMhBLkiRJksqSgViSJEmSVJYMxJIk\nSZKksmQgliRJkiSVJQOxJEmSJKksGYglSZIkSWWp0YE4Iioi4u6IeDkiXoqIz0dEl4iYHBEzIuKR\niKhozsZKkiRJkkpPS82PTekh/hnwp5TSLsDuwCvAucDklFJf4NH8tSRJkiSpvLXI/NioQBwRnYED\nUkq3AKSU/pVSWgQcAUzIN5sADG+WVkqSJEmSSlJLzo+N7SHeAXgvIm6NiGcj4lcRsSXQPaU0N99m\nLtC9WVopSZIkSSpVLTY/tmlCuc8Cp6eUnomIcdTq3k4ppYhIdRUeM2ZM4fmgQYMYNGhQI5shSZIk\nSdqUpkyZwpQpU9a3SZPy48bU2ED8NvB2SumZ/PXdwHnAnIjYJqU0JyJ6AO/WVbg4EEuSJEmSSlft\nTs5LL7209iZNyo8bU6OGTKeU5gBvRUTffNEhwHTgAeD4fNnxwH1NbqEkSZIkqWS15PzY2B5igDOA\n30ZEW+A14ESgNTAxIk4CqoCjmtxCSZIkSVKpa5H5sdGBOKU0DdinjlWHNL45kiRJkqRPmpaaH5ty\nH2JJkiRJkkpWU4ZMS5IkSZLUIkREN+C7QHvghpTSzPrK2EMsSZIkSfokuAZ4BLgX+F1DChiIJUmS\nJEklJyIejogDixa1BV7PH5s3pA4DsSRJkiSpFB0NHBERd0bETsCFwFjgOuDUhlTgNcSSJEmSpJKT\nUloInJ2H4cuBd4AzUkoLGlqHgViSJEmSVHIiog9wMrASOBvYCbgzIh4C/jOl9FF9dThkWpIkSZJU\niu4gm0BrCvCblNKTwBBgETC5IRXYQyxJkiRJKkXVk2htSXarJVJKCZgQEXc1pAIDsSRJkiSpFJ0K\n/BxYRTZ0uiCltKwhFRiIJUmSJEklJ6X038B/N6UOryGWJEmSJJUlA7EkSZIkqSwZiCVJkiRJJSsi\nPtPYsgZiSZIkSVIpuyEinomIUyOi84YUNBBLkiRJkkpWSumLwLeAXsCzEXFHRBzakLIGYkmSJElS\nSUspzQAuBM4BBgI/i4h/RsSI9ZUzEEuSJEmSSlZE7BER1wIvAwcDX0kp7QIcBFy7vrLeh1iSJEmS\nVMquA24GLkgpLatemFJ6JyIuXF9BA7EkSZIkqZQdDnyYUvoIICJaA1uklD5IKf1mfQUdMi1JkiRJ\nKmX/BbQret0emNyQggZiSZIkSVIp2yKltLT6RUppCVkorpeBWJIkSZJUyj6IiM9Vv4iIvYEPG1LQ\na4glSZIkSaXsLGBiRMzOX/cAjm5IQQOxJEmSJKlkpZSeiYhdgH5AAv6ZUlrVkLIGYkmSJElSqdsb\n2IEs4342IqhvhmkwEEuSJEmSSlhE3A7sCDwPfFS0ykAsSZIkSfpE+xzQP6WUNrSgs0xLkiRJkkrZ\ni2QTaW0we4glSZIkSaVsa+CliHgaWJEvSymlI+oraCCWJEmSJJWyMfm/CYii5/UyEEuSJEmSSlZK\naUpE9Ab6pJT+KyLa08Cs6zXEkiRJkqSSFRGjgbuAG/NF2wH3NqSsgViSJEmSVMpOA74ILAZIKc0A\nujWkoIFYkiRJklTKVqSUqifTIiLa0MBriA3EkiRJkqRS9kREXAC0j4jBZMOnH2hIQQOxJEmSJKmU\nnQu8B/wv8B3gT8CFDSnoLNOSJEmSpJKVUvoIuCl/bBADsSRJkiSpZEXE63UsTimlHesrayCWJEmS\nJJWyfYqebwF8A9iqIQW9hliSJEmSVLJSSvOKHm+nlMYBhzekrD3EkiRJkqSSFRGfY81tlloBewOt\nG1LWQCxJkiRJKmXXsCYQ/wuoAo5qSEEDsSRJkiSpZKWUBjW2rIFYkiRJklSyIuIHrOkhLizO/00p\npf9YV1kDsSRJkiSplH2ObKbp+8mC8FeAZ4AZ9RU0EEuSJEmSStn2wGdTSksAIuIS4E8ppW/VV9Db\nLkmSJEmSSlk3YFXR61X5snrZQyxJkiRJKmW/AZ6OiD+QDZkeDkxoSEEDsSRJkiSpZKWU/j0i/gx8\nMV90QkrpuYaUdci0JEmSJKnUtQeWpJR+BrwdETs0pJCBWJIkSZJUsiJiDPAj4Nx8UVvg9oaUNRBL\nkiRJkkrZ14BhwAcAKaVZQMeGFDQQS5IkSZJK2YqU0urqFxGxZUMLGoglSZIkSaXsroi4EaiIiNHA\no8CvG1LQWaYlSZIkSSUpIgL4PbAzsAToC1yUUprckPIGYkmSJElSKftTSmk34JENLeiQaUmSJElS\nSUopJeAfETGgMeXtIZYkSZIklbJ9gWMi4g3ymabJsvLu9RU0EEuSJEmSSk5E9EopvQkcBiQgNrQO\nA7EkSZIkqRT9EdgrpVQVEfeklEZsaAVeQyxJkiRJKnU7NqaQgViSJEmSVJYcMi1JkiRJKkW7R8SS\n/Hm7oueQTarVqb4KDMSSJEmSpJKTUmrd1DocMi1JkiRJKksGYkmSJElSWTIQS5IkSZLKUpMCcUS0\njojnIuKB/HWXiJgcETMi4pGIqGieZkqSJEmSSllLzI9N7SE+E3gJSPnrc4HJKaW+wKP5a0mSJEmS\nWlx+bHQgjojtgKHAr4HIFx8BTMifTwCGN6l1kiRJkqSS11LzY1N6iK8FfgisLlrWPaU0N38+F+je\nhPolSZIkSZ8MLTI/NioQR8RXgHdTSs+xJt3XkFJKrOkKlyRJkiSVoZacH9s0stx+wBERMRTYAugU\nEbcBcyNim5TSnIjoAbxbV+ExY8YUng8aNIhBgwY1shmSJEmSpE1pypQpTJkyZX2bNCk/bkyRBfEm\nVBAxEDg7pfTViLgKmJ9SujIizgUqUkrn1to+beg+TzhhDL17j2lSO4vdPvEQjrn+i81WX9V9VYwf\nN77Z6pMkSZKkUhURpJTq7Ane0Py4sTXXfYirE+4VwOCImAEcnL+WJEmSJKlai8mPjR0yXZBSegJ4\nIn/+PnBIU+uUJEmSJH3ytLT82Fw9xJIkSZIklRQDsSRJkiSpLBmIJUmSJEllyUAsSZIkSSpLBmJJ\nkiRJUlkyEEuSJEmSypKBWJIkSZJUlgzEkiRJkqSyZCCWJEmSJJUlA7EkSZIkqSwZiCVJkiRJZclA\nLEmSJEkqSwZiSZIkSVJZMhBLkiRJksqSgViSJEmSVJYMxJIkSZKksmQgliRJkiSVJQOxJEmSJKks\nGYglSZIkSWXJQCxJkiRJKksGYkmSJElSWTIQS5IkSZLKkoFYkiRJklSWDMSSJEmSpLJkIJYkSZIk\nlSUDsSRJkiSpLBmIJUmSJEllyUAsSZIkSSpLBmJJkiRJUlkyEEuSJEmSypKBWJIkSZJUlgzEkiRJ\nkqSyZCCWJEmSJJUlA7EkSZIkqSwZiCVJkiRJZclALEmSJEkqSwZiSZIkSVJZMhBLkiRJksqSgViS\nJEmSVJYMxJIkSZKksmQgliRJkiSVJQOxJEmSJKksGYglSZIkSWXJQCxJkiRJKksGYkmSJElSWTIQ\nS5IkSZLKkoFYkiRJklSWDMSSJEmSpLJkIJYkSZIklSUDsSRJkiSpLBmIJUmSJEllyUAsSZIkSSpL\nBmJJkiRJUlkyEEuSJEmSypKBWJIkSZJUlgzEkiRJkqSyZCCWJEmSJJUlA7EkSZIkqSwZiCVJkiRJ\nZclALEmSJEkqSwZiSZIkSVJZMhBLkiRJksqSgViSJEmSVJYMxJIkSZKksmQgliRJkiSVJQOxJEmS\nJKksGYglSZIkSWXJQCxJkiRJKkuNCsQRsX1EPB4R0yPixYj4br68S0RMjogZEfFIRFQ0b3MlSZIk\nSaWkJefHxvYQrwK+l1LaFdgXOC0idgHOBSanlPoCj+avJUmSJEnlq8Xmx0YF4pTSnJTS8/nzpcDL\nwLbAEcCEfLMJwPDmaKQkSZIkqTS15PzY5GuII6I3sBfwd6B7Smluvmou0L2p9UuSJEmSPhlaWn5s\nUiCOiA7APcCZKaUlxetSSglITalfkiRJkvTJ0BLzY5vGFoyIzcgO5raU0n354rkRsU1KaU5E9ADe\nravsmDFjCs8HDRrEoEGDGtsMSZIkSdImNGXKFKZMmbLebZqSHzemRgXiiAjgZuCllNK4olX3A8cD\nV+b/3ldH8RqBWJIkSZJUump3cl566aU11jc1P25Mje0h3h84BnghIp7Ll50HXAFMjIiTgCrgqCa3\nUJIkSZJUylpsfmxUIE4p/YV1X398SOObI0mSJEn6JGnJ+bHJs0xLkiRJklSKDMT/v717j7t1rvM/\n/nrbyDEkKlSMw0RDQjJqUkppUqnoJMRkOklpKkb9JlLZSqgMpnKKaISkSJJDJyE5H2LK+VxROVTY\n798f3++d5d4Ha+1929f6rvV+Ph4e+7qvq3vvz9V9r7Wuz/fw+URERERERMRYSkIcERERERERYykJ\ncURERERERIylJMQRERERERExlpIQR0RERERExFhKQhwRERERERFjKQlxREREREREjKUkxBERERER\nETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERERESMpSTEERERERERMZaSEEdERERERMRYSkIc\nERERERERYykJcURERERERIylJMQRERERERExlpIQR0RERERExFhKQhwRERERERFjKQlxRERERERE\njKUkxBERERERETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERERESMpSTEERERERERMZaSEEdE\nRERERMRYSkIcERERERERYykJcURERERERIylJMQRERERERExlpIQR0RERERExFhKQhwRERERERFj\nKQlxREREREREjKUkxBERERERETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERERESMpSTEERER\nERERMZaSEEdERERERMRYSkIcERERERERYykJcURERERERIylJMQRERERERExlpIQR0RERERExFhK\nQhwRERERERFjKQlxREREREREjKUkxBERERERETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERE\nRESMpSTEERERERERMZaSEEdERERERMRYSkIcERERERERYykJcURERERERIylJMQRERERERExlpIQ\nR0RERERExFhKQhwRERERERFjKQlxREREREREjKUkxBERERERETGWkhBHRERERETEWEpCHBERERER\nEWMpCXFERERERESMpSTEERERERERMZaSEEdERERERMRYSkIcERERERERYykJcURERERERIylJMQR\nERERERExlpIQR0RERERExFhKQhwRERERERFjKQlxREREREREjKUkxBERERERETGWpjwhlrS5pGsk\nXSdpt6n++yMiIiIiIqItw5onTmlCLGkacBCwObAW8DZJa07lvzEVHrz/wa5DmBLnnHNO1yFMidzH\n8BiFe4Dcx7DJfQyX3MdwGYX7GIV7gNzHsMl9DJd5vY9hzhOneoZ4Q+D/bN9g+yHgm8Drp/jfmGcP\nPpCEeJjkPobHKNwD5D6GTe5juOQ+hsso3Mco3APkPoZN7mO4TMF9DG2eONUJ8YrAzT1f31LPRURE\nRERExHga2jxxwSn++zzFf99I+dCH9uTee6fu7zv9jG9yw703TNnft/QiS3Pg9AOn7O+LiIiIiIhg\niPNE2VMXm6SNgD1tb16//k9ghu19e/43Q/t/RkRERERERMw725o47idP7MpUJ8QLAr8GXg7cBlwA\nvM321VP2j0REREREREQzhjlPnNIl07YflrQz8ANgGnDYMNxkREREREREdGOY88QpnSGOiIiIiIiI\naMVUF9UaOrW/1et5tIrZLcApwzIiMY4kLVTLrfeee6rt33UVU0TEnIzCe5SkpYDVgN/avqfreKJN\nkjYB7rD9a0kvBv4ZuMr2qR2HFhExV6a67dJQkbQbcFz98vz63wLAcXUjdxMkPUnSAj1fbyrpI5Je\n3WVcg5L0Mkm3AHdIOkPSKj2Xf9hVXONI0rKSPinpXZIWkPRxSadK+rykZbqOr1+S3ihp2Xq8vKSv\nS7pC0v9KWqnr+AYhaXNJ/yZp5Unnd+wmoqkhab2uYxiUpFdLul7STyU9X9KVwPmSbpX0iq7j65ek\nb0h6aj1+FXA5sC9wqaQ3dxrcgCQ9WdKqszi/ThfxTBVJn+06hkFI+iKwD3CMpL2BzwGLALtK2q/T\n4MaQpAUlvUfSpyW9aNK1T3QV11SQdG3XMQxK0qqSjqg/jyUlfVXSlZK+NfmzvSWSVpe0laS1uo7l\niTO42RkAAB3HSURBVDLSS6YlXQesNYvZyIUpo5mrdRPZYCRdBmxi+x5JHwXeAJwGbAJcZHv3TgPs\nk6RfAtsDVwFvAqYD29o+T9LFtp/faYDzQNJZtjftOo5+Sfo+cBnwZGBNyoPyt4DNgHVsD0Wj9Mcj\n6Wrba9bj44HzgBMoBRu2sb1Zl/H1S9I+wIuAXwGvBb5o+0v1WjOvjZ7kV5T2CgJOodwTtn/VUWgD\nkXQp8FZgaeBU4F9t/6KuODq2oZ/HFbb/qR6fRyleckNNks+y3UQyWZP3A4G7gIWAHWxfUK+19Pr4\n8ixObwd8HbDtXeZzSAOTdBXwT8CiwK3Airbvl7QQcInt53YaYJ8kfQD4pu27Ja0GHA6sQyn48y7b\nl3caYJ8kHUb5WVwIvAM41/aH67WWXht/5tHPjAmLAQ9QXhtP7iSwAUn6CXAs5bPjHcARwPGUZ6tt\nWnlOlHQOsJXt30naFvh/wI+BFwJfnXg+GSWjvmT6EcpS6RsmnV+hXmvFAj3L294KvNj2g5KmAxcD\nTSTEwMK2r6zHJ0i6GjipzuQ3Q9LlzPzGvcbE+UYeMlew/WpJAm61/dJ6/sc1GWhF7yqXVW1PzHod\nKWnXLgKaS68Fnm/7IUl7Ulax/APQ0j0A/BL4BfDXnnNPAb5Qj1823yOaO49MbKuRdL/tXwDYvrq+\nZlohSUvZ/iPlM+9mgPqQM63b0AbycWB927dL2hD4uqQ9bJ/UdWADegNwLnBG/VqUz/RfdhbR4GZQ\nPv8eqX+653xLr4332p4YoPgScABwMmWi4VDKAGULNrS9NoCkg4CDJZ0EvL3bsAZ2BCWJ/JjtO+r7\n7G9tr/I43zdslrB9CICk99meWDVxWB2EaUXvFqEPAv9s+/eSFqOstk1C3JgPAWdK+j/qgwDwTGB1\nYOfOohrcnyWtXUcs76aMBj5IGSlv6QPob5KebvsOANtXSno5ZQZmpqVwQ+x64M/ApymjlwJ+AmxB\nOz8PSXoKsASwuKRVbF9fZ44W6ji2QZwr6VOUJXznSHqj7ZMkvQy4t+PYBjFtYiWL7XslvRb4CmXW\nfuFOIxvM1pQPz8/bPg1A0vW2W0mEJ/xR0ruBpYB76uDK8cArgPs6jWwwewFn1wflnwHHS/ou8FLg\n9C4DG9A027cD2L6gvr6/J+mZHcc1qLWAvYHNgf+wfZukT9o+quO4BnEa5fNuEeAwyu/ULyiJ5I+7\nDGxAvQNCy9n+dj0+R9KSXQQ0l/7+eV0/Q3aS9EngR5TP9ybY3kXSBsCxkr4DHNR1THNphqR/pHx2\nLCrpBbYvlLQ6bW1TfUjSSrZvoTzvPlDP/5W27qNvI71kGqCOgm9ImSk2ZYnPL20/3GlgA6h7pI6m\nLHE18GLKB8/awP62v9FheH2TtBlwt+1LJp1fGtjZ9qe7iWxwkt5Imb3bz/Z36kN/MyOZkt5GWYIo\n4H3Ae+qltYC9bP9PV7ENom5/+DiwQz21EuWN+7vAbrZv6iq2QUg6Ffic7XMnnf80sIftZj6A6sPk\n3pT33I8A57T02gCQ9CzgE5RZrz0psy07AjdREplmijLWB7GdKAPBC1EGh0+2/YNOAxuApJ9Tttf8\npufck4FvA/9iu6VBIyStD+xHSS53tv3sjkMaiKSNKauhzqvLjd8A3AicYHtGt9H1R9JnKO9Rn6LM\n0j8InARsCrzJ9hYdhtc3Sd8AjrH9/Unn3wUcYrulAe6JZ/adga2A1Ww/o+OQBlIneQ6hfHbsRHlO\nXIeSIO9k++QOw+ubpJcC/w2cSFnltR5lZcuLgdN7Zr5HxsgnxKNCpZn1K3nsQ80ZqRTaHUlLUB78\n/wHYwPaKj/MtQ6X+Tqku010IeB5wm+3bOg5trtSBlQWB37uxNzZJiwLYfnAW1yZGaZtS9xPvDzzX\n9nJdxxPtkrQucL/t6yadXxh4s+1juols7qkUynwfsJHtd3Qdz7yQtJztu7uOY1CSdqAMBq8KPInS\nheRkYHrdZhAdkbQCsO7ESqOWSVoOuKeliTj4+zPV23ls3vEd29d0GtgTJAlxDAVJ37fdVNXsCfVh\nbSPbh3Ydy7yo+10O7jqOuVGXWj2Tsq/t2hbfsOueqQ0os9zN3kevek9L2v5T17EMoq4AObfumVqe\nMpu3HnAlZYa4iQGKmnRtTZmtmCg293rgauDQVmbzRpmk9W1f1HUc/VLpbnEwZbXdLpTVa4tQEsp3\n2j6zw/DGXq098XzgytY+P2oCtjmPbZP6A9stbX+aaG/3ah67MrW5+xg3SYgbIGlz26fX46UpBWo2\npFQG3tX2nV3G16+6TGxWv3ACTrX99Pkc0jxRw/2UJf3HLE7vAXwGwPb+8zeiuaPSD/MLlP3C6wM/\npxTmeIiyxPLmOXz70Bih+1iWstztVkrV1v8ENqZUlv9sKytaNDrVyw8BlqPsQ/8TJXH5DqXewR22\nP9hheH2TdA9l6d5xlOrYTT64aNZV2L8DvA7aqMKu0anA/jrKKru/dB3LvJB0su0t6/HrKVuhzqEU\nBdvH9hEdhtc3SdsBn6S04JwYcHwmpTrzXq3ssx+V+5gTSV+x/e9dxzHVkhA3QD2l81VK7N8OfI2y\nb2eTiTfDYSfpEWZfdGMj24vOz3jmVi3ocjSluNlFwLttX1+vNdHmQNJ9lIeZqyZOUYohHQhge6+O\nQhuIpEuAzVxaZ6wCHGB7y7pf/aO2X9lxiH0ZofsYlXZev7b9j/X4Itvr91y71Pbzuouuf6ptl+qW\niDuBZ9j+a90ucbFrddphJ+nXwJcpy/dWpvxOHeda/bsVkmYwcxX2jeo5Wig+J+lXtterxzfbfmbP\ntUtsr9tddP2T9CCl3sRplIGWH9huqfsIMNPz4XnA2/1ogcyWWqtdS6mYfe+k88sAF9hevZvIBjNC\n9/GU2V0CLmtti2A/Rr3K9CjagLKvwsABkt7ZcTyDuIaSPM7UbF1SEzNg1eeBV/FoP+UfStrW9nnd\nhjWQtSj7OxcH9rT9gKTtW0mEeyzQs3ftJuDZALZ/KOmL3YU1sFG5j1Fp53WuRqN6+cNQqs9KutD2\nX+vXD9fkrBUP2D4IOEjSsykzlAfXh8zjbO/RbXh9G4Uq7KNSgf0aSgGtrSnF/45UaVd0nCcVN2zI\nwhOD8y6t1Vp6jc/OqMzatXYfv6MUypuVkawJkoS4DctJ+jBlZGapSddaafMDpVrr7Krl7jIf45hX\nzfdTdqm+vJWkLSmtyQ7oOqa5dFFdNXE2Zdnh2QCSFqet1gCjch/SaLTz2plSvfzX9etdJU1UL9+2\ns6gGd4ekJWzfZ/tVEyclPYPHzlI2w/aNwL7AvpKeA7yl45D6ZvtESWcAe9eCTh/pOqa5sD2PVmB/\nJWXW/geUgbydOoxrYHULx1eAr9TXxJspv1cr9s58D7l1JP25Hi8i6Rku/bqfRFufHZ+hfA6ewWOX\nGr+SUry0FaNyH78FXl7fbx+jsQmsvmXJdAMk7cljR5cOsX1XfQPf1/Z23UQ2byT9C3UvtO0zuo6n\nX5J+CWzh2k+5nluJ2k/ZdjO9/+Dv1bL3pCzzeUnH4QxEpcrsTpTluZcCh9t+RKVq89Ns39BlfP0a\nofsYiXZevdRw9fLZqQMtSzRUf2J/2x/uOo6ppFRh79SctjdJWrmV99zZqe9ba9n+edex9KsOpr4K\nWKGeupWyz/sP3UU1uFG4D0k7Az/1pDap9doutr/UQVhPqCTEjagFK1YEfmH7vp7zr/ak/nPDStIF\ntjesxzsB76f0kXwl8D3b+3QZX780Qv2UI6aaZm7ntS5l+XQz7bwkrWP7sq7jmGoqPaJXB347eY9b\nzH8qVcCXdGMtfiRNVAL+UW/iKGlH24d3FtgAJL3M9tldxxGjTaXi9OrAb1opKjmuWlpOMbYk7ULp\njbczcGVd5jrhs91ENVd6l0y+m1JEaC9KQrxNNyENzvYPZzVqZvveVpJhSUtLmi7pGkn3SPpDPZ5e\nE/smjMp9zEktVNWSGZS2UVBmimcArVVyvVjSdZL2lrRW18HMLUkH9xy/mNI26gvAFZJe01lgc0HS\n5pIOlfTd+t+hNTFrlu0ZE8mwpP/qOp5+SNqH0pFgbeBH9flkwge6iWpw45AMS7q86xj6JWlNSd+X\ndKqkVSUdKeleSRfUCaEmSPqGSt9hJL2KUlhyOnCppDd3GtyAJD1Z0qqzON9EobZBZQ9xG/4dWN/2\nfZJWpuxbXdn2gd2GNbBpdSmJgGkTRYRs3y+pmYblNdHaHdgSeBplOftdlEGL6Y3MvBwP/Ah4KXCn\nbdcl+NvXa01UNWZE7kOPtmOZ6RKlp2QT6mDd/wAzJL2H8uB8H/AcSe+1fUqnAfbvMspe4bcDp9T9\nw8cC32xsKeU/9xx/GtjS9q9UepV+i7LNY+ipFJZbHfg6ZfkhlH7du0j6V9st1aCYnZ2AT3UdRB9e\nCzy/rgDZEziu/j7t2m1Yg+mdza5bno6itLy7itJPeabin8NI0ptmcXqipdcz5nM48+IrwOco9SfO\nBnYDdgReAxxEaXnXguf1FMjcE3iJ7RtqHY2zKM8lQ68m7wcCd9WVXjvYvqBePoqGnkv6lSXTDZB0\npe3n9ny9BKUn41XAyxpqc3ADj+6FNvCiWvxhSeAnDd3HGZQk7ChmTsI2dQMtciRda3uNQa8NmxG6\nj1FpSXYJsDmwGGUv9AtsX6NSGfgk97QvGmaT9xdKeiGlsvHWwE22N+4suAHosS1ZJt9TEy3iACRd\nN6t2JZIEXGd7tQ7CGpgeLX40K4vaHvpJCvX06K5fL0hJZp4MrNn7rDLMJr02vkXpG3sYpajhzrab\nSMAkPUQZrJtcUVrAVq3UNJn08/i/3td0Y+9VVwIb2/6jpJ9SWqM+MnGtodfHpcDm9Rl9Q8pg5B61\n20IzP49BDP2bbwBlhGbdiWW6daZ4C8qbdzNLF2yvPJtLj1B6KrdiZdv79p6wfTswXdKOHcU0qBsl\nfQw4aqKwjqSnU5L6mzqNbDCjch+j0pLME8XmJN1k+5p68sa6X7JJts8Hzpf0H0BLheee07NschVJ\ny9i+R9I02qr6/RdJG/bMUEzYEHiwi4Dm0j2U4oV3TL7Q0Ov8t5I2cW1NZPthYEdJnwbe2G1oc+0f\nbW9dj78t6ZOdRjOYy4H9bM+0PFpSE0l9Na3neP9J11p6r9oLOFvSQcDPgOMlfZeyiu30LgMb0LT6\nXIvtC1RaDn5PUivV1weWhLgN2wEP9Z6oy5W2p4zMNs32A8D1XccxgFFIwt5CWfZ9rqSn1XN3AqdQ\nWk+0YlTuY09GoyUZkhawPQPYoefcgrT1ULPfrE7W+zpn/oYyTybvvbu//rkM0MSe1eqdwCF1NdFE\nK5OVgD/Va604GngWMFNCDBw3n2OZW1szi56qtj8h6dAO4plbK0n6EmUm9amSFrI98ZzV0rPxhyiv\ng1lpaYDiYElL2v6z7d7aB6sBZ3YY10BsHy/pYsoWiNUpn3svpPS3/kGnwQ3mT5JWtf0bKJM+NSn+\nNtDELPegsmQ6YkB1H/TulKVVk5Ow6a2U1tejlcvPt/3nnvOb225pJPMxJB1tu6Vesaj0jHwrpRrz\nmZK2ATambIv4qu2/dRpgn+rSqsttPzjp/MrAi20f00VcMRrq1pQV65e3TsxgRLckva83iWmBpHfy\n6F5bA9+1/Yf6O/YB23t0GV9ElyStC9xv+7pJ5xcG3jyKn+VJiCOmkKQdbB/RdRyPR6Uy6PuBqynF\nET5o++R6rZn9IXUp0sRDzYRNKcUrbPt1nQQ2IEnHUpaMLQbcSykschLwCgDb23cX3byRtKzt33cd\nxyBUWmX8J2UW8jTbx/ZcO9j2+zoLbgC9g1u1GOAXqL3fgV3dSB/iOZH0nIml+a2YNBs5ce6ptn/X\nVUz9qtsGJtsD+AyA7cnLXeMJJOkA4ETbP+06lqkm6Szbm3YdxyAkLUvpCHMrZVvjHjw6uP1Zp/XS\n0EpCHDGFJN1se+j3WEi6glKsaaJy+YnA0bYPbCwhvpjyQfM1SlERUZYevhVgYp/bsJN0ue2169Li\n24AVbD9ciwZdZnvtjkPsi6R9KfvZ7pa0AaWi5gzKsrHtbZ/TZXz9knQScC1wPqXS6d+AbWz/pbXX\nR0+hmsOA2ymvlTdQir1sOafvb0Er77lQet9Slk0vClxEqRtwfb3WxO+VpPso1cmvmjgFfJBSkRaX\nVopDb1LicjhlAKy5xEXS3cCNwPLANylLcy/uNqrB1VoHkwe316C8D9t2E/VyVNokXgYsRdmychml\nov9mwDq2X99heH2TdA/lufA44CyPQbLY0j6JiKGgOff2e9ocrg0T2b4PwKUlwCbAiSrVgDXnbx0q\nG1Aexj4OfNT2xZL+0koi3EN12fRilIflpYDfA4vQ1vv0a2zvVo/3A95i+0JJa1A+WJuoMg2santi\n/923JX2c0nO1iYeZ2dgAWLc+2BxQl4w2QdKX53C5pX7jnwdeRUm63gT8UNK2ts/rNqyBrEUperQ4\nsKftByRt30oi3OMYSrKyAfAOyqqJfSmJy5FAK6/1W2xvUN9j3wocUwdWj6Ukx020j6LUkfkzpT3c\nA5TnkJ8AW9DWM8kKtl9dB7Nvtb1JPf/jWrm5FXcBlwB7A0erVGI/zvYvug3ridPSg1bEsFie0lpm\nViPIP5/PscytUalc/giwv6TjKQ/5d9Hm+9phlOXrCwKfoFSmvB7YCPjfLgMb0LSe5aCL2L4QwPa1\nde9RKxbuKQ6G7c9IuhU4l7KcvRXLSfow5YFyqUnXWnrIfCfwEeCvPLagkyi9oluxsO0r6/EJkq4G\nTpK025y+aZjYvgnYSqXn+Jl1yW6LJicuL63nW0tcgPIeS+lj/SlJzwPeBnwfWLXTwPpk+3WS3kgp\nFLuf7e9Ietj2jV3HNiDVOjNLAItLWsX29Sp9iFsqLPmA7YOAg+pEyVsphc+WoSTGI7fHvsUHx4iu\nnQosMatlSZJamZkcqcrltm8Btq5J/R+7jmdQtg+oST22b5X0dcr+4a/MotXMMDsYOE3SPsDpkr5I\n2Qu9KWW0uRXfA15O6U0KgO0jJd0BzGm2cth8DViyHh8BPBW4u1bFb+nn8UvgCts/m3xB0p7zP5y5\n9jdJT59ou2T7SpXWOKfSSOIywfbJks6kVMhvpWVUr1FJXGZi+1JKH/jdu45lEC49bs8A9lZpYdnS\nIOqEfSiD2wL+DfhqGXNhLUpLpubUQYl9gX0lPYfS3WPkZA9xRERMmbpP8r2UlhMLUtrknAwcPrmQ\n0DCT9EJgRl3y/VzKqpCrbZ/WcWh9k7QRJeY/SlqM8oC8HnAlsI/tezsNsE81cfmLS4u+ZknaDLh7\nYmVOz/mlgZ1tf7qbyMaPpLdR9j0LeB/wnnppLWAv2//TVWyDUG1V1HUcU61WOd7IdkutvIC/txlU\nnWRYCHgecJvt2zoOrW+SDrC9a9dxzE9JiCMi4gnXSgV2+Pus4+aUmaIzKH0kz6bsLzyjlcRF0lWU\nQi4PS/oqpQ/xCZTVB+v07JOOjrRWhX1UKrDDaCQuUKa6KXuhVwIeAa5trfI6jNR9PAv4k+17a9HS\nF1AGJq/oNLCYoyTEERHxhGusGvAVwLqUJXt3AivVWdZFgQsaqvp9te016/GvbK/Xc+1S28/rLrr+\nqfSG/S9KxfL/Aj5AKUp1NaVlXBP9iOdQhX1hYLsWqrCPSgX2WVGb/ZQ3obRTu5dStPDnlEJzDwHb\n2m5iOfsI3cfuwLspr4vPU2of/IxSD+Rw21/oMLy+SdofOGkU23nNTvYQR0TElHicCuzLz7dA5t3D\nth8GHpb0G9t/BLD9oKQZHcc2iCsl7Wj7cOBSSS/oqfr9t66DG8CRlH3dSwDnAN8AXkOpBHwo7VQE\nHoUq7CNRgV2z6acsaRFoqp/yF4HN6iDLKsABtl9Ul+cfBryy2/D6Nir3sR1l2f3iwA3AKvWeFgcu\noCT9LdgWeImkptt5DSIJcURETJVRqMAO8FdJi9U9q72zqktTlvK14l3AFyV9Argb+LmkWyhFkN7V\naWSDWd72lwEkvdf29Hr+y5Jauo9RqMI+KhXY92LmfsoL8GgRulYsYPvuenwT8GwA2z+sRQ1bMSr3\n8XAdOP0bpX3UHwBs3y+ppSW5o9LOq29JiCMiYqqMQgV2gE1s/wVg4sG/WhDYvpuQBleLZm1f932u\nQi1yNlHluCEL9BwfPYdrw24UqrCPSgX2UemnfJGkwyg1Dl5X/6TOSLb02hiV+7hY0nGU36uzgKMk\nnU55jV81x+8cQq238xpE9hBHRETE0JK0N/C5ydV0Ja1OqZa9VTeRDa5WYX8PsAYNV2GfIOlfgA2B\ny22f0XU8g1Lpp/wx4ADK79gqHYc0kLqyYCdgTUqrpcNtP1LrHTzN9g1dxtevEbqPhYCtKbUBTqAU\nZHw7cCPw37bv7zC8vrVeD2BuJCGOiIiIJvXskW6CpDWBFYHzexN8SZvbPr27yPoj6QLbG9bjnYD3\nA9+m7PH8nu19uoxvbkhagtJPeUPbL+k4nIjOjWo7rzlpaRlCRERERK9mlrhK2oUyG7wzcEWdnZzQ\nSiK5UM/xuymFkPaiJMTbdBPSvLF9n+2PtJgMS1pa0nRJ10i6R9If6vH0WvOgeZK+33UM/ZL0DEmH\nSPpvSctK2lPS5ZKOr9XyW9HUSompkD3EERERMbQep3r50+ZbIPPu34H1bd9X+5OeIGll2wd2G9ZA\npkl6CqUI1bSJQki1aNDD3YbWv5os7g5sSfkdMnAXZcBiet1/34LjgR8BLwXutO2aeG1frzVRnVnS\nerO7BLS0dPdIRqMi/sWSfsujFaab2/88qCyZjoiIiKEl6U7mUL3c9grzOaS5IulK28/t+XoJ4ERK\nsZ2X2V63s+D6JOkGSvJI/fNFtm+XtCTwkxbuAUDSGZRE8ihmTiQ3td1KInmt7TUGvTZsJD0C/Hg2\nlzeyvej8jGdu9e69lXST7Wf1XGup9/vFlNZLbwfeTKmYfSzwzVb2cw8qM8QRERExzEalevldkta1\nfQmUpbqStqD0WV2n29D6Y3vl2Vx6BHjDfAxlXq1se9/eE7ZvB6ZL2rGjmObGjZI+Bhxl+04ASU+n\nJPY3dRrZYK4B3j2rdj6Sbu4gnrk1KhXxsX0FsAelP/cLKe2XfloT/Y27jW7qNfXDiYiIiPFie0fb\nP5nNtbfN73jmwXbAY1pe1crS2wPN7V/tZfsB29d3HccAbpT0MUl/X3Iv6emSdqOtRPItwFOBc+se\n4nsoS3WXpczstWJPZp+T7DIf45hXp9SVH9j++MRJSasBv+4sqnlk+3zbuwLPoiTJIydLpiMiIiJi\nbNR90LtTet5OJMV3AqdQ9hD/oavYBtV65fLZkfR129t1HccgJD2JMpN6q+0zJW0DbEzZFvFV23/r\nNMA+SdrG9je6jmN+SkIcEREREQFI2sH2EV3H0Y9aufz9wNWU4lMftH1yvdZML1lJ36XsSVfP6U2B\nswDbfl0ngQ1I0rHANGAx4F5Kca2TgFcA2N6+u+jmjaRlbf++6zieKNlDHBERERFRfApoIiFm5srl\nJzZYuRxgJcos6teAGZTEeANgvy6Dmgtr215b0oLAbcAKth+WdAxwWcex9U3SdOALtu+WtAGlYvkM\nSQsD29k+p9MAnwBJiCMiIiJibIxQKy/Zvg/A9g2SNqEkxc/msbOtw24D4IPAx4GP2r5Y0l9st1Q0\nD0B12fRiwKLAUsDvgUVoK+fawvbu9Xg/4C22L5S0BnAcsH53oT0xWvrhRERERETMq+WZQyuv+RzL\nvGi+cjmA7UeA/SUdDxwg6S7azFEOoyxfXxD4BHC8pOuBjYD/7TKwAU2TtFAt+reI7QsBbF9bZ4lH\nTvYQR0RERMTYkHQ4cMSsqpdLOq6V6uWSngk8ZPuOSedF6RH9024imzc1qd/YdnMVjSWtCGD7VknL\nUPYP32j7gm4j65+kD1AKzu1DqYC/DGUv9KbAP9jetsPwnhBJiCMiIiIiIgIASS8D3gusTpnxvgU4\nGTi8zhyPlCTEERERERERMUctVWEfRBLiiIiIiIiImCNJN9t+ZtdxTLUWN6xHRERERETEFHucKuzL\nz7dA5qMkxBEREREREQGjU4W9b0mIIyIiIiIiAuBUYAnbF0++IKm13tB9yR7iiIiIiIiIGEsLdB1A\nRERERERERBeSEEdERERERMRYSkIcERERERERYykJcURERERERIylJMQRERERERExlv4/vwGxsmJ5\nwbwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f18320c8050>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The probability that the distributions for payload/histograms/GECKO_THREAD_ACTIVITY_MS (normalized) are differing by chance is 0.00.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA8QAAAHZCAYAAABAe/KbAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3XucVXW9//HXBxAFucwgF0ElVAJFQ60k01Q0L6SlGKmQ\n1479yGtaWd4Vj55I0yNZx1upUJqGmeblkHJUtM6plFI83gI9jhcEFOTmhUvy/f2xFts9wzAzzAwy\n2/V6Ph77MXuvtb7f9V1rZvZjv/f3u74rUkpIkiRJklQ07TZ0AyRJkiRJ2hAMxJIkSZKkQjIQS5Ik\nSZIKyUAsSZIkSSokA7EkSZIkqZAMxJIkSZKkQjIQS/rYi4iJEXHJeqh3eES81sD6moj44lrW7RkR\nL7R2myS1HRFxYETc1cRtx0XEr1p5/w2+R7Ww7j4R8VxEdFwf9UvSR8VALKkIUv5Y7yKiX9kH0LXu\nN6X0x5TSdk2or9U/JG9IEXFORPxb/rxrRPx7RLwcEe9ExCsRcUdEDCvbflW+bmnZ48yy9YPyMm9F\nxKKImBER34mIdhExIC/fLt82IuKnEfF8RPTNX38/ImZGxHv5/n/Y2Af8iJhS1pYVEbG87PU1awsh\nETEtIk7Inw/P27Y0IpZExAsRcXyd7Rs89nyb4/PtjqizvLz+pRHxWkT8JiI+uw6/q4iI/4uIZ9ey\n7tsR8b95G1+LiMkRseO6nJ+IuC4iJtVT/04RsSwiqlf/D0TEVnXOR93zc37dgBYRm0XEmxFxQAPH\nufpc/a6eNqyKiEfKlh0aEU9FxOL8b+6hiBjQwGn8N2B8Q+e5zEfyHrU2a/u7XZuU0jzgEWDs+muV\nJK1/BmJJRREf0X4OAqZ8RPtqkYjosAF2exBwf0RsDDwM7AAcDHQFtgduB75Up8zQlFLXsscVABGx\nLfBX4BVgx5RSFXA48BmgS3kFeSi+HtgL2CulNAe4Gvh/wDH59l8CvghMbugAUkpfWt0W4FbgsrK2\nndxQUWqHntl5mW7Ad4CfR8Sgphx7meOAt4Fj69nf7LJ27ga8APwxIvZt6PjK7AX0ArauJ0j/BPg2\ncBpQDQwC7gYOXsfzMxH4akR0rrP8GODelNLC1QtSSq+llLqU1Q21z8+lwGzgwrJ6JgD3pZQebORY\n3wJ2i4geZcuOA2aS/84iYiAwCfhOSqk7sDXwH8AH9VUYEbsC3VJKjzey71KRJm7XltwKfGtDN0KS\nWsJALKnNiGyI8dkR8WxEvB0RN+XBiYioioj78t6etyPi3ojYIl93eERMr1PXdyPi7rXs5/9FxKyI\nWBARv4+IvmXrfhIRr+Y9QNMj4gtl6zpFNvz67bzXbNd6qj8I+M+y17tE1mu5KCJuLzueWr0xEXFW\nRLweH/YW7hsRI4BzgCPzHrAn8237RcQ9eftnRcQ367RxUt7G5yLiB3X2U5MvexpYGhHt83P+Yr7v\nZyNiZNn2x0fEf0fWk7swIl6KiM/ny1+NiHkRcWzZ9gfldSzJj+d7ZetWB6c/kwWeLYCRKaXnUua9\nlNKdKaWL6/u91eNi4E8ppTPz3ipSSjNTSkenlJaUbdcBuBn4NDA8pfRWRHwSOAn4ekrprymlVSml\n54BRwIiI2KeJbYBWCDIppSlkwfZTTd5pxCfIQuv/Aw6MiD4N1D87pXQR8Avgsibu4jjg92Rf8BxX\ntt9PAicDo1NK01JKK1NK76eUfp1Sqq/utZ6flNJfyELsqLL62wNjgF82sZ3lvgmcnPfuHgjsS/Zl\nQ2NWkAX60WVtOIIs8K1u/87AyymlR/K2v5NS+l1KaW29ql8CppUvaOj9hSx4b5K/TyyJiL9FxNCy\nsmu8R+TLN46ICRExO39cFWsZ5RBZj/c2Za8nRsQl+RcSU4B+8eGohc0js/r9YX5kowyqy6p8HNgm\nIrZq6ORKUltmIJbU1nwdOADYliw8nZ8vbwfcCPTPH+8DP8vX3UPWi1U+BPkYst6cWvIPkT8k60ns\nS9a7eHvZJo8DO5H1ev0auKPsw+VFZL1C2wAHkoWEUo9fRGwE7AlMXb0o38+BebmhwPH1tGkwcArw\n2by38ACgJqX0h7ytt+c9YLvkRW4HXs3b/zXgh2UB7qL8/GwN7A8czZpDMUeTfVivSil9ALwIfCHf\n98XALXXC1TBgBtAjPye/IeuF3Tav/2fxYQ/fjcDYvK4dyHqBVzsQ+K+UUgL2A/6QUnq/7vmox9oC\n1ReB3zah/K+BTwL7lvU4fhF4LaVU64uUlNLrwF/Izt1HIrLh3YcAPcl+F7VWN1D0WOCJlNJdwPPA\nUU3Y3V3ApyOiUyNt6kwWUm8hC4Wj48MRBfWeuxb4JbV7uPcDNqL2F0tNklJ6hayH+GbgWuCklNLi\nJhb/VVk7DgSeAd4oW/93YLv8y6HhEdGlbgV17Aj8o86yht5fAjiUbITC6vV3519a1fsekZc7j+x/\ndKf8MYwP3zcbk4CUUnoPGAG8sXrUQkppLtkogEPIvnjpCywk6xXPCqf0T7K/2Z2buD9JanMMxJLa\nkgT8LO/NWkh2/d0YgJTS2ymlu1JKy1JK75AFxb3zdcvJQtrRABGxA/AJ4L46dUMWGm5MKT2VUlpB\n1gP7+Yjon9d1a0ppYd5j+O/AxsDgvOzhwL+llBblwekn1A4sewEzUkrvlu3z6pTS3Px47qX+D44f\n5PvZISI2Sim9mlL6v3xdlO8j74nZHTgrpbQipTSDrNdv9Qf5w4EfppQWp5Rm19PG1W2anZ83Ukq/\nzT/8klKaDMwCPldW5uWU0qQ8yE4GtgT+Ne8ZnErWuzYw33ZFfhzd8jY8WVbPwXwYcjYD5pYd1855\nD/TiWHOysb/n61Y/9i+rY04957Ou/YDf1uk17lm+/zrm5HW3RL86bV4IfKG+bYD3gN+RDcWdUWeb\ntR07ZL/zX+fPf039w6breoPs76Gqke2+CiwDHgTuJwuoX87X1frdtYJbgL0jol/++ljg1vzLmnWW\nUvoZ2d/hkymle9ah3J+BHpENWz+WOl+o5f+Tw8lGNkwG3oqImyNi07VUWQUsrVNHQ+8vANPzXucP\ngH8HNiEb7t7Qe8TXyf4f56eU5pN9qXVMU4+bD98f6vvy5VvA+SmlN1JKK/O6vxb5dfm5pUD3ddif\nJLUpBmJJbU358MNXgX6Q9VhFxPX5kN/FwKNA94hY/SFuEtkHQ8g+DP4m/wBX1+peYQDy8LqA7EMu\nEXFmZEONF+VhpTtZeCJvS932lTuILDyUKw8O71Pn2ta8DS8CZwDjgHkRcVuUDeOuox/wdlnoXt2O\nfmXry9v4ej111BriGRHHRsSTZcFtR2oHwnl1joGU0ltrOa5RZOehJrJJpHbL99GOvFc4325BWZvJ\nv6CoJgtiG9dp7y4ppeqyx9T66mjAl4GLIuIbZcvmk/0t1Kdfvr4l3qjT5mrgT/VtA3Qju565vhnJ\n6z32iNgDGED2RRDAbcCnImKnRtq1BdmXIosa2e444I48uC0nC+yrh00vYO3nbp2llF4FHgOOyXtd\nD6V5w6XLPQ+sMRlYE/yK7Lro4WS96bVCYj68/siUUm+y0SB7kfXQ1mch2e+2pJH3Fyj7f82/gHod\n6NfIe0Q/yt7TqP1+0FIDgLvK3hueA/4JlI8g6Urjf0+S1GYZiCW1Nf3rPJ+dP/8e2RDqYSmb0GZv\nynpPU0p/BVZExF5kvcprm5n5DbIPeQDkvTubAbMjYk/g+8DhKaWqPKws5sMPxXPqaV+5L9GMYZ55\n+29LKe1J1rOd+PA6z7rDnd8g68UqD9bl52kOUH49X33X9pUP8/4EcAPZcMwe+TE/QzOvi00pTU8p\njSSbjOluPpygalfglZTSgvz1Q8ABseZkSuuy3/+i7NrTBvwP8BXgJxExpmz/W0U28dGHO8964D+X\nr/9I5CMVziILtIc2sdhxZOfqqYiYQzbMe/XyhhwG/K2hoeoRsSXZtbdHR8ScvP5RwEERsRnZudky\nIj7TxLY2xSSyL7JGkY1IKB9Z0NzZl5vzN3wL2bXl96eUljW0YT5k/C6yL5Dq8zTZe1bWmMbfX6Ds\n/zX/EmlL8mHbDbxH1HpPI3s/KB/qXe49oPx/ri8fnt/6zvOrwIg6X8p0TtmkdKsn5htIdkmFJFUk\nA7GktiTIJsTZIrLZXs/jwx6wLmQ9kYvzdRfVU/6XZNcVr0gp/U+deld/6LwN+EZkk+5sTDb0+i95\nL1VXst6P+RHRMSIupHYPz2TgnMgm+NqSrCcp20HE1sDGKaW61ww2ftDZrYP2zduznGyo6urhonOB\nAat7wlM2gc//AOMjm0xnKPAvZB/k67ZxC+BUGg4Um+br5wPt8l7UtX3Ab+w4NoqIoyKiez7kc2nZ\ncRxE7SHsvyQL73dFxA75dZKbAJ+tp71rCzYXAbtHxOWrr3mOiIGR3aKnVs9cSukxst7nGyLiqyml\nWcB1wK0R8bl8/zsAdwJTU0oP0zStMjNwPprhSmrPkFxv/fl5OoJsMq2dyh6nAV+PbEKo8u0j/5+6\nCDgBOLeR5hxDNiP1oLK6B5H1Vo7Jz901wG0RsXf+v7JJRIyOiLMaa/9a3EkW5MaRzTzdnDpaWoaU\n0suspdc3Ir4QEd+MiF756+3Ivmj581qq+0/yyzpyjb2/AHwmIg7Lg+YZZO8Ff2nkPeI24PyI6BkR\nPcn+htb2heBTwFH53/uI/FhXmwdsVud/5zqyOQr658fcK7Lr3VcbRjbfwXq517EkfRQMxJLakkR2\nLeSDwEtk17Jemq+bAHQiC27/QzYjat3g9CuyiZxuqbO8dLublNJDwAVkH8DfIJt8anS+3R/yx0yy\nCWvep/aw6IvJhia+nG/3y7I2HMyaw6XrO75U5zVkQ4THk936ZQ7ZEMpz8nV35D8XxIczaY8h6xF6\ng2wo64VlAe5fyYLLy2Tn8Q6y6ynrb1A2s/KVZB/q55KF4fKhvfXdS7mhgH008HI+rH0sH070VGv2\n7XwY7j5kQzDvJ+spe4Fssq5a99QFZkTte/H+e17H/wGfz8/FsxGxiGySrSeAd+q2NaX0X8CRwKSI\nOJjsy4JfkP29LCX7m3qYpvU6l6ql/vPRlF7NutvcBPTP27Zafcd+KPAu8MuU0purH2QTSXUgmxAq\nkc8YnB/b42T/G3vn56EhxwLXlNedslm8r8vXkVL6NtmXT/9BNjT4xbxdda/ZbdL5SdmkTneSDem+\ntTl1NLFMQ9uvbsv/rL6mvk49C8kmmPrf/LxOIfv/u7zeCrNe7sXx4X21G3t/SWSjKo4km3H8KOCr\n+ZdLDb1HXApMJ+uRfjp/fmmdelc7nSzELyS7xOSusva+QBau/y+yWeo3J5uD4B7gwYhYQvY+Mays\nvqPIJi+TpIoV2SUqkrThRcTLwAnr0DtXt3wnsl6OXVJKL7Vq4xrf9/3AT1M2M3SbEREnAUeklNbl\nNkKt3YY+wN9TSltsqDZIG0Jkk6CdnFI6bEO3pbVFRG+y20rtnA/7l6SKZA+xpI+Tk4DHP+ownJtG\nnXuObgiR3Tt0j8hu5TMY+C5lvUAbSLe8HVKhpJSmfhzDMEA+cmCIYVhSpevQ+CaS1PZFRA3Z0MCR\nG2L/KaUfb4j91qMj2dDWrclmfr2N7HrPDSa/5nTWhmxDc0TEs6w5cRpk91m+7aNuT2vKJ3iqbwK4\nlLL73H6sRMS5fDjEuNxjKaWD61kuSSoIh0xLkiRJkgqpwSHTEXFTRMyLiP8tW9YjIqZGxMyIeDAi\nqsrWnRMRsyLihYg4YH02XJIkSZLU9rXlXNlgD3E+pOodspksP5UvuxyYn1K6PL+9QnVK6eyIGEI2\nO+yuZLNE/hcwKKW0qk6ddklLkiRJ0sdYSql0C7z1kStbS4M9xCmlP5JNzV/uEGBS/nwSH16vdyhw\nW0ppZUqphuwWDMOoR0ppgz4uuuiiDd4Gj8PjaIuPj8MxeBxt7+FxtK2Hx9G2Hh+H4/g4HIPH0fYe\nHkfbeqzrcXxUubI1NGeW6T4pux8hZLc36ZM/70d278vVXidL9JIkSZIklWsTubJFt11KWfxvaAi0\nw6MlSZIkSWu1IXNlc267NC8iNk8pzY2IvsCb+fLZwFZl222ZL1vDuHHjSs+HDx/O8OHDG9zhGWeM\nY9GiZrR0Lf705/uoWVTTavVVbVLFhB9NaLX6mqqx81YpPI624+NwDOBxtDUeR9vicbQtH4fj+Dgc\nA3gcbY3H0bY0dhzTpk1j2rRp61pti3Nla2j0tksRMQC4N9W++HlBSumyiDgbqEq1L34exocXPw9M\ndXYQEXUXNer448cxYMC4dSrTkFsm78fR13yh1eqrubuGiRMmtlp9kiRJklSpIoJUNqlWvmwArZgr\nW0uDPcQRcRuwN9AzIl4DLgR+BEyOiBOAGuAIgJTScxExGXgO+Cdw8vpqtCRJkrS+RETjG0kCqHcS\nrbracq5sMBCnlMasZdV+a9n+h8APW9ooSZIkaUOyX0dqXFO/PGrLubJFk2pJkiRJklSpDMSSJEmS\npEIyEEuSJEmSCslALEmSJGmdjRkzht///vcbuhkVp6amhnbt2rFq1aoN3RTRvPsQS5IkSYVyxtln\nsGjZovVWf9UmVUz40YQW1/PMM8/wve99j7///e8sWLBgjdD19ttvc8IJJzB16lR69uzJ+PHjGTNm\nbfMdrd3TTz/N008/zW233QbAI488wumnn85rr71G+/bt2WuvvfjZz35Gv379Svs96aSTeOihh4gI\nDjzwQK699lq6du0KwL333ss555zDK6+8wtChQ/nFL37B9ttvD8DEiRM54YQT6Ny5c2n/999/P3vt\ntReQBcyTTz6Zv/zlL2y88cZ87WtfY8KECbRv337dT6AKx0AsSZIkNWLRskUMGDlgvdVfc3dNq9TT\nsWNHRo8ezSmnnMLIkSPXWH/KKaewySab8Oabb/Lkk09y8MEHs9NOOzFkyJB12s/111/P0UcfXXq9\nww47MGXKFLbYYgtWrlzJ+eefz0knnVTqQT7//PNZvHgxNTU1rFq1ilGjRjFu3DiuvPJKZs2axdFH\nH82UKVPYbbfduPzyyznkkEN44YUXSqF2jz324LHHHqu3LSeffDJ9+vRh7ty5LFy4kP33359rrrmG\n0047bZ2OScXkkGlJkiSpgrzxxhuMGjWK3r17s8022/DTn/60tG7QoEF84xvfqDfgvvvuu/zud7/j\nkksuoXPnzuyxxx4ceuih/OpXvwJg/vz5fPnLX6a6uprNNtuMvfbaa623n/rDH/7A3nvvXXrdu3dv\ntthiCwBWrVpFu3bteOmll0rra2pqGDlyJF26dKFbt26MHDmSZ599FoAHHniAPffck91335127dpx\n1llnMXv27FoBuKHbYNXU1HDkkUfSsWNH+vTpw4gRI0p11/Xiiy+y9957U1VVRa9evRg9enRp3emn\nn07//v3p3r07n/3sZ/nTn/5UWjdu3DgOP/xwjjnmGLp168bQoUOZNWsW48ePp0+fPvTv35+pU6eW\nth8+fDjnnHMOn/vc5+jevTsjR45k4cKF9bZp8eLFnHDCCfTr148tt9ySCy64oNSz31B71ToMxJIk\nSVKFWLVqFV/5ylfYZZddeOONN3jooYeYMGECDz74YKNlZ86cSYcOHRg4cGBp2U477VQKj1deeSVb\nbbUV8+fP580332T8+PH13mf23Xff5eWXX2bw4MG1lr/66qtUV1fTuXNnrrzySn7wgx+U1p1yyinc\ne++9LFq0iIULF3LnnXdy0EEHAdm9bMsD76pVq0gp8cwzz5SWPfnkk/Tq1YvBgwdz6aWX8sEHH5TW\nnXHGGdx+++28//77zJ49mylTpvClL32p3nNwwQUXMGLECBYtWsTs2bP59re/XVo3bNgwZsyYwcKF\nC/n617/O4YcfzooVK0rr77vvPo499lgWLlzILrvswoEHHghkX1BceOGFfOtb36q1r1/96lfcfPPN\nzJkzhw4dOtTaV7njjz+ejh078tJLL/Hkk0/y4IMP8otf/KLR9qp1GIglSZKkCvHEE08wf/58zj//\nfDp06MDWW2/NN7/5TW6//fZGy77zzjt069at1rKuXbuydOlSIBtuPWfOHGpqamjfvj177LFHvfUs\nWrSoVLZc//79WbhwIfPnz+fSSy+tFZh32WUXVqxYwWabbUbPnj3ZaKONOOmkkwDYb7/9ePTRR3n0\n0UdZsWIFP/zhD1mxYgXvvfceAHvvvTfPPvssb731FnfeeSe33XYbP/7xj0t177nnnjzzzDN069aN\nrbbail133ZVDDz203rZ37NiRmpoaZs+eTceOHdl9991L64466iiqq6tp164d3/3ud1m+fDn/+Mc/\nSuv32msv9t9/f9q3b8/XvvY13nrrLc4++2zat2/PkUceSU1NDUuWLAGykH/ssccyZMgQOnfuzCWX\nXMLkyZPX6OmeN28eU6ZM4aqrrqJTp0706tWrFPAba69ah4FYkiRJqhCvvPIKb7zxBtXV1aXH+PHj\nefPNNxst26VLl1JgW23x4sWlYPv973+fgQMHcsABB7Dtttty2WWX1VtPVVUVQClI11VdXc1xxx3H\noYceWhr6e8QRRzB48GDeeecdlixZwjbbbFO6Bnnw4MFMmjSJU089lX79+rFgwQKGDBnClltuCcDW\nW2/NJz7xCQB23HFHLrzwQn77298CWW/yiBEjGDVqFO+99x7z58/n7bff5qyzzqq3bZdffjkpJYYN\nG8aOO+7IzTffXFp3xRVXMGTIEKqqqqiurmbx4sXMnz+/tL53796l5506daJnz56lHvROnToB2ZcO\nq2211Val5/3792flypW16oPs97ly5Ur69u1b+n2eeOKJvPXWW422V63DSbUkSZKkCtG/f3+23npr\nZs6cuc5lBw0axD//+U9efPHF0rDpGTNmsOOOOwJZYL7iiiu44oorePbZZ9l3333Zdddd2XfffWvV\ns+mmm7Ltttvyj3/8Y609litXruTNN99kyZIlVFVVMWPGDK699tpScPzWt77FnnvuWdp+1KhRjBo1\nCsh6oG+88UZ23XXXtR7L6p7Wt99+m9dee41TTz2VjTbaiB49enD88cdzwQUX1Bvo+/Tpww033ADA\nf//3f7Pffvux9957M3v2bH784x/z8MMPs8MOOwDQo0ePBq9dbsyrr75a6/lGG21Ez549effdd0vL\nt9pqKzbeeGMWLFhAu3Zr9lWurb3bbLNNs9ul2uwhliRJkirEsGHD6Nq1K5dffjnvv/8+H3zwAc88\n8wzTp08vbbNs2bLSta/Lly9n+fLlQBZkv/rVr3LhhRfy3nvv8ac//Yl7772XY445BshuZfTiiy+S\nUqJbt260b99+rbcuOuigg3j00UdLr++66y5mzpzJqlWreOutt/jud7/Lpz/96VJv8q677srPf/5z\nli1bxvvvv88NN9zATjvtVCr/t7/9jQ8++IC33nqLsWPHcuihhzJo0CAApkyZwrx58wB44YUXuPTS\nS0szaPfs2ZOtt96aa6+9lg8++IBFixYxadKkWnWXu+OOO3j99deBrKc7ImjXrh1Lly6lQ4cO9OzZ\nkxUrVvCv//qva/Smr4uUErfccgvPP/887733HhdeeCGHH374Gtdk9+3blwMOOIDvfve7LF26lFWr\nVvHSSy+VJhRbW3vVejybkiRJUoVo164d9913H0899RTbbLMNvXr1YuzYsaXwVlNTQ+fOndlxxx2J\nCDp16lS6ny/ANddcw/vvv0/v3r05+uijue6660rrZ82axf7770/Xrl3ZfffdOeWUU2rNJF1u7Nix\n3HrrraXXs2fPZsSIEaUZmDt06MBdd91VWn/TTTdRU1PDlltuyZZbbklNTQ2TJk0qrT/jjDOorq5m\nu+22Y7PNNuPnP/95ad3DDz/MTjvtRJcuXTj44IMZNWoU5557bmn97373O6ZMmUKvXr345Cc/ycYb\nb8xVV11Vb7unT5/ObrvtRteuXTn00EO5+uqrGTBgACNGjGDEiBEMGjSIAQMG0KlTJ/r3718qFxFr\nhNmGXkcExxxzDMcffzx9+/ZlxYoVXH311fVu+8tf/pIVK1YwZMgQevToweGHH87cuXMbbK9aT7Rk\nGECzdhiR1nWfxx8/jgEDxrVaG26ZvB9HX/OFVquv5u4aJk6Y2Gr1SZIkacOpO+sxwBlnn8GiZYvW\n2z6rNqliwo8mrLf614ejjjqKI444Yq0TWBXZPvvswzHHHMO//Mu/bOimrFf1/a+ULV9zivI2yGuI\nJUmSpEZUWlj9KJT3EGtNH3XHo5rHIdOSJEmS1Mrqu4ez2h57iCVJkiSpFT3yyCMbuglqInuIJUmS\nJEmFZCCWJEmSJBWSgViSJEmSVEgGYkmSJElSIRmIJUmSJEmFZCCWJEmS1GY98MADHHbYYRu6GRVp\n+PDh3HjjjS2q48wzz+S6665rpRa1Pd52SZIkSWrEGWeMY9Gi9Vd/VRVMmDBu/e1gPRg7diyPPfYY\ns2bN4qabbuK4446rtf6qq67i8ssv57333uNrX/sa1157LR07dlzn/Zx33nlcc801ayx/9NFH2Wef\nfTjvvPO45JJLAJg7dy5jx47lb3/7G3PmzKGmpob+/fuXypx55pncc889zJ07ly222IJzzz2XY445\npknH9Mwzz/C9732Pv//97yxYsIBVq1at87F81CKixfdDPvPMMxk2bBgnnHACG220USu1rO0wEEuS\nJEmNWLQIBgwYt97qr6lZf3WvLzvvvDOjR4/mrLPOWiN0PfDAA1x22WU88sgj9O3bl8MOO4yLLrqI\n8ePHr9M+nnjiCZYsWcKwYcNqLV+5ciWnn346u+22W619t2vXjoMOOohzzz2X3XfffY36unTpwn33\n3cegQYN4/PHHGTFiBAMHDuTzn/98o8fUsWNHRo8ezSmnnMLIkSPX6Tgq2eabb852223HPffcw6hR\nozZ0c1qdQ6YlSZKkCjJgwACuvPJKdtppJ6qqqhg9ejTLly8vrf/5z3/OJz/5STbbbDMOPfRQ5syZ\nU1rXrl07rr/+egYNGkR1dTWnnnrqWveTUuJHP/oRAwcOpGfPnhx55JEsXLiwtP7kk09m3333ZZNN\nNlmj7KS4hXMyAAAgAElEQVRJk/jmN7/J9ttvT1VVFRdeeCETJ04srb/sssvYcsst6datG9tttx0P\nP/xwvW2YMmUKw4cPX2P5lVdeyYgRIxg8eDAppdLy3r17c+KJJ/LZz3623vrGjRvHoEGDABg2bBh7\n7rknf/7zn5t0TIMGDeIb3/gGQ4YMqbfuur7zne/Qp08funfvztChQ3n22WcBuP/++9lll13o3r07\n/fv35+KLLy6VqampoV27dkycOJH+/fvTo0cPrr/+ep544gmGDh1KdXU1p512Wmn7iRMnsscee3Da\naadRVVXF9ttvv9ZzCXDTTTcxZMgQevTowYgRI3j11VcbbS9kQ6/vv//+Jh13pTEQS5IkSRUkIrjj\njjt44IEHePnll3n66adLYfPhhx/m3HPP5Y477mDOnDl84hOfYPTo0bXK33///UyfPp2nn36ayZMn\n88ADD9S7n6uvvpp77rmHxx57jDlz5lBdXc0pp5zSpDY+99xz7LTTTqXXQ4cOZd68eSxcuJB//OMf\n/Md//AfTp09nyZIlPPjggwwYMKDeep555hkGDx5ca9krr7zCzTffzAUXXFArDK+r999/nyeeeIId\nd9yx2XWszQMPPMAf//hHZs2axeLFi7njjjvYbLPNgKyX+pZbbmHx4sXcf//9XHvttfz+97+vVf7x\nxx/nxRdf5De/+Q2nn34648eP5+GHH+bZZ59l8uTJPPbYY7W2HThwIAsWLODiiy/mq1/9KovqGd//\n+9//nvHjx3PXXXcxf/589txzT8aMGdNoewG22247ZsyY0ernqS0wEEuSJEkV5tvf/jabb7451dXV\nfOUrX+Gpp54C4NZbb+WEE05g5513pmPHjowfP54///nPtXoCzz77bLp168ZWW23FPvvsUypb1/XX\nX8+ll15Kv3792Gijjbjooov47W9/26RrZ9955x26d+9eet2tWzcAli5dSvv27Vm+fDnPPvssK1eu\npH///myzzTb11rNo0SK6du26xrFfeumlbLrppi26RvbEE09k55135oADDmhW+YZ07NiRpUuX8vzz\nz7Nq1SoGDx7M5ptvDsDee+/NDjvsAMCnPvUpRo8ezaOPPlqr/AUXXEDHjh3Zf//96dKlC2PGjKFn\nz57069ePPffckyeffLK0be/evTn99NNp3749RxxxBIMHD+a+++5bo03XXXcd55xzDoMHD6Zdu3ac\nc845PPXUU7z66qsNthega9eu9YbsjwMDsSRJklRhysNKp06dePfddwFKvcKrbbrppmy22WbMnj27\n3rKdO3fmnXfeqXcfNTU1HHbYYVRXV1NdXc2QIUPo0KED8+bNa7R9Xbp0YcmSJaXXixcvBrJgNXDg\nQCZMmMC4cePo06cPY8aMqTWsu1x1dXWteu69917eeecdDj/8cCAb1t2cXuLvf//7PPfcc0yePHmd\nyzbFPvvsw6mnnsopp5xCnz59+Na3vsXSpUsB+Otf/8o+++xD7969qaqq4vrrr2fBggW1yvfp06f0\nvFOnTmu8Xv37Bthiiy1qlf3EJz5R7/l85ZVXOP3000u/z9U9wG+88UaD7YXsi4yqqqoWnJG2y0As\nSZIkfUz069ePmpqa0ut3332XBQsWrBGamqJ///784Q9/YOHChaXHe++9R9++fRstu8MOO9TqeZ4x\nYwZ9+vShuroagDFjxvDHP/6RV155hYjgrLPOqreeoUOHMnPmzNLrhx9+mOnTp9O3b1/69u3L5MmT\nmTBhwjrdlumiiy7igQce4MEHH6RLly5NLreuTjvtNKZPn85zzz3HzJkz+fGPfwzA17/+dUaOHMnr\nr7/OokWLOPHEE1s0Y3X5lx2QBd9+/fqtsV3//v254YYbav0+3333XXbbbbcG2wvw/PPPs/POOze7\njW2ZgViSJEmqcKt7SceMGcPNN9/MjBkzWL58Oeeeey677bZbrVsP1VeuPieeeCLnnntuabj1W2+9\nxT333FNav3LlSpYtW8aqVatYsWIFy5YtK9V37LHHcuONN/L888+zcOFCLrnkEr7xjW8AMHPmTB5+\n+GGWL1/OxhtvzCabbEL79u3rbcNBBx1UazjxJZdcwqxZs5gxYwZPPfUUhxxyCGPHjuXmm28ubbNs\n2TKWLVu2xnOA8ePHc9tttzF16tRSOC/X0DGtrm/FihUALF++vNZkZuWmT5/OX//6V1auXEnnzp1r\nHeM777xDdXU1HTt25PHHH+fXv/71Og/7Lm/Tm2++ydVXX83KlSu54447eOGFFzjooIPWKHPiiSfy\nwx/+kOeeew6gdK1wY+2F7BZXX/rSl9apjZXCQCxJkiRVsPLraL/4xS9yySWXMGrUKPr168fLL7/M\n7bffXmvbtZWt6/TTT+eQQw7hgAMOoFu3bnz+85/n8ccfL63ff//96dy5M3/5y18YO3YsnTt35o9/\n/CMABx54ID/4wQ/YZ599GDBgANtuu21pNuXly5dzzjnn0KtXL/r27cv8+fPXejum1bMxr95vly5d\n6N27N71796ZPnz506tSJTTfdtNZw3s6dO9OtWzcigu22245NN920tO68887jtddeY+DAgXTt2pWu\nXbvyox/9qEnHVFNTQ+fOndlxxx2JCDp16sT2229fb7uXLFnC2LFj6dGjBwMGDKBnz558//vfB+Ca\na67hwgsvpFu3blxyySUceeSRa/xOGlO+zec+9zlmzZpFr169uOCCC7jzzjvrDfsjR47krLPOYvTo\n0XTv3p1PfepTpQnVGmrvnDlzeP755z+2t5qKlszM1qwdRqR13efxx49r1fu+3TJ5P46+5gutVl/N\n3TVMnDCx1eqTJEnShhMRa/ScnnHGONbnnEJVVTBhwrj1t4MKNnXqVK655hruuuuuDd2UNmfixInc\neOONpdC+Ppx55pkMHDiQE088cY119f2vlC1v3mxnH7EOG7oBkiRJUltnWN1w9t9/f/bff/8N3YzC\nuuKKKzZ0E9Yrh0xLkiRJUgVqyW2nlDEQS5IkSVIFOu6443jsscc2dDMqmoFYkiRJklRIBmJJkiRJ\nUiEZiCVJkiRJhWQgliRJkiQVkrddkiRJkupw5l6pGAzEkiRJUpmU0oZugqSPiEOmJUmSJEmFZCCW\nJEmSJBWSgViSJEmSVEgGYkmSJElSIRmIJUmSJEmFZCCWJEmSJBWSgViSJEmSVEgGYkmSJElSIRmI\nJUmSJEmFZCCWJEmSJBWSgViSJEmSVEgGYkmSJElSIRmIJUmSJEmFZCCWJEmSJBWSgViSJEmSVEgG\nYkmSJElSIRmIJUmSJEmFZCCWJEmSJBWSgViSJEmSVEgGYkmSJElSIRmIJUmSJEmFZCCWJEmSJBWS\ngViSJEmSVEgGYkmSJElSIRmIJUmSJEmFZCCWJEmSJBVSswNxRHwnIp6JiP+NiF9HxMYR0SMipkbE\nzIh4MCKqWrOxkiRJkqTK01bzY7MCcURsAZwGfCal9CmgPTAaOBuYmlIaBDyUv5YkSZIkFVRbzo8t\nGTLdAegcER2AzsAbwCHApHz9JGBky5onSZIkSfoYaJP5sVmBOKU0G7gSeJXsQBallKYCfVJK8/LN\n5gF9WqWVkiRJkqSK1JbzY3OHTFeTpfkBQD+gS0QcXb5NSikBqaUNlCRJkiRVrracHzs0s9x+wMsp\npQUAEfE74PPA3IjYPKU0NyL6Am/WV3jcuHGl58OHD2f48OHNbIYkSZIkaUOaNm0a06ZNa2iTFuXH\n9am5gfgVYLeI6AQsIzvAx4F3geOAy/Kfd9dXuDwQS5IkSZIqV91OzosvvrjuJi3Kj+tTswJxSunx\niPgt8Hfgn/nPG4CuwOSIOAGoAY5opXZKkiRJkipQW86Pze0hJqU0DhhXZ/HbZGlfkiRJkiSg7ebH\nltx2SZIkSZKkimUgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJ\nklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJ\nkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJ\nkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJ\nkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFY\nkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQg\nliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZ\niCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRI\nBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQV\nkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJ\nhdTsQBwRVRHx24h4PiKei4jPRUSPiJgaETMj4sGIqGrNxkqSJEmSKk9bzY8t6SH+CfCfKaXtgaHA\nC8DZwNSU0iDgofy1JEmSJKnY2mR+bFYgjojuwJ4ppZsAUkr/TCktBg4BJuWbTQJGtkorJUmSJEkV\nqS3nx+b2EG8NvBURN0fE3yPi5xGxKdAnpTQv32Ye0KdVWilJkiRJqlRtNj92aEG5TwOnppSeiIgJ\n1OneTimliEj1FR43blzp+fDhwxk+fHgzmyFJkiRJ2pCmTZvGtGnTGtqkRflxfWpuIH4deD2l9ET+\n+rfAOcDciNg8pTQ3IvoCb9ZXuDwQS5IkSZIqV91OzosvvrjuJi3Kj+tTs4ZMp5TmAq9FxKB80X7A\ns8C9wHH5suOAu1vcQkmSJElSxWrL+bG5PcQApwG3RkRH4CXgG0B7YHJEnADUAEe0uIWSJEmSpErX\nJvNjswNxSmkGsGs9q/ZrfnMkSZIkSR83bTU/tuQ+xJIkSZIkVayWDJmWJEmSJKlNiIjewLeBzsC1\nKaVZjZWxh1iSJEmS9HFwJfAgcBfw66YUMBBLkiRJkipORDwQEXuVLeoIvJw/Nm5KHQZiSZIkSVIl\nOhI4JCJuj4htgfOB8cDVwMlNqcBriCVJkiRJFSeltAg4Mw/DlwJvAKellBY2tQ4DsSRJkiSp4kTE\nQOBEYAVwJrAtcHtE3A/8R0rpg8bqcMi0JEmSJKkS3UY2gdY04JcppceAEcBiYGpTKrCHWJIkSZJU\niVZPorUp2a2WSCklYFJE3NGUCgzEkiRJkqRKdDLwU2Al2dDpkpTSe02pwEAsSZIkSao4KaX/Bv67\nJXV4DbEkSZIkqZAMxJIkSZKkQjIQS5IkSZIqVkR8qrllDcSSJEmSpEp2bUQ8EREnR0T3dSloIJYk\nSZIkVayU0heAo4D+wN8j4raIOKApZQ3EkiRJkqSKllKaCZwPnAXsDfwkIv4REaMaKmcgliRJkiRV\nrIjYKSKuAp4H9gW+nFLaHtgHuKqhst6HWJIkSZJUya4GbgTOSym9t3phSumNiDi/oYIGYkmSJElS\nJTsYeD+l9AFARLQHNkkpvZtS+mVDBR0yLUmSJEmqZP8FdCp73RmY2pSCBmJJkiRJUiXbJKX0zuoX\nKaWlZKG4UQZiSZIkSVIlezciPrP6RUR8Fni/KQW9hliSJEmSVMnOACZHxJz8dV/gyKYUNBBLkiRJ\nkipWSumJiNgeGAwk4B8ppZVNKWsgliRJkiRVus8CW5Nl3E9HBI3NMA0GYkmSJElSBYuIW4BtgKeA\nD8pWGYglSZIkSR9rnwGGpJTSuhZ0lmlJkiRJUiV7hmwirXVmD7EkSZIkqZL1Ap6LiMeB5fmylFI6\npLGCBmJJkiRJUiUbl/9MQJQ9b5SBWJIkSZJUsVJK0yJiADAwpfRfEdGZJmZdryGWJEmSJFWsiBgL\n3AFcny/aErirKWUNxJIkSZKkSnYK8AVgCUBKaSbQuykFDcSSJEmSpEq2PKW0ejItIqIDTbyG2EAs\nSZIkSapkj0bEeUDniNifbPj0vU0paCCWJEmSJFWys4G3gP8FvgX8J3B+Uwo6y7QkSZIkqWKllD4A\nbsgf68RALEmSJEmqWBHxcj2LU0ppm8bKGoglSZIkSZVs17LnmwBfAzZrSkGvIZYkSZIkVayU0vyy\nx+sppQnAwU0paw+xJEmSJKliRcRn+PA2S+2AzwLtm1LWQCxJkiRJqmRX8mEg/idQAxzRlIIGYkmS\nJElSxUopDW9uWQOxJEmSJKliRcT3+LCHuLQ4/5lSSv++trIGYkmSJElSJfsM2UzT95AF4S8DTwAz\nGytoIJYkSZIkVbKtgE+nlJYCRMRFwH+mlI5qrKC3XZIkSZIkVbLewMqy1yvzZY2yh1iSJEmSVMl+\nCTweEb8jGzI9EpjUlIIGYkmSJElSxUop/VtE/AH4Qr7o+JTSk00p65BpSZIkSVKl6wwsTSn9BHg9\nIrZuSiEDsSRJkiSpYkXEOOAHwNn5oo7ALU0payCWJEmSJFWyw4BDgXcBUkqzga5NKWggliRJkiRV\nsuUppVWrX0TEpk0taCCWJEmSJFWyOyLieqAqIsYCDwG/aEpBZ5mWJEmSJFWkiAjgN8B2wFJgEHBB\nSmlqU8obiCVJkiRJlew/U0o7Ag+ua0GHTEuSJEmSKlJKKQF/i4hhzSlvD7EkSZIkqZLtBhwdEa+Q\nzzRNlpWHNlbQQCxJkiRJqjgR0T+l9CpwIJCAWNc6DMSSJEmSpEr0e2CXlFJNRNyZUhq1rhV4DbEk\nSZIkqdJt05xCBmJJkiRJUiE5ZFqSJEmSVImGRsTS/HmnsueQTarVrbEKDMSSJEmSpIqTUmrf0joc\nMi1JkiRJKiQDsSRJkiSpkAzEkiRJkqRCalEgjoj2EfFkRNybv+4REVMjYmZEPBgRVa3TTEmSJElS\nJWuL+bGlPcSnA88BKX99NjA1pTQIeCh/LUmSJElSm8uPzQ7EEbElcBDwCyDyxYcAk/Lnk4CRLWqd\nJEmSJKnitdX82JIe4quA7wOrypb1SSnNy5/PA/q0oH5JkiRJ0sdDm8yPzQrEEfFl4M2U0pN8mO5r\nSSklPuwKlyRJkiQVUFvOjx2aWW534JCIOAjYBOgWEb8C5kXE5imluRHRF3izvsLjxo0rPR8+fDjD\nhw9vZjMkSZIkSRvStGnTmDZtWkObtCg/rk+RBfEWVBCxN3BmSukrEXE5sCCldFlEnA1UpZTOrrN9\nWtd9Hn/8OAYMGNeidpa7ZfJ+HH3NF1qtvpq7a5g4YWKr1SdJkiRJlSoiSCnV2xO8rvlxfWut+xCv\nTrg/AvaPiJnAvvlrSZIkSZJWazP5sblDpktSSo8Cj+bP3wb2a2mdkiRJkqSPn7aWH1urh1iSJEmS\npIpiIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIk\nSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIk\nSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYk\nSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYgl\nSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZi\nSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKB\nWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVk\nIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIh\nGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJU\nSAZiSZIkSVIhGYglSZIkSYVkIJYkSZIkFZKBWJIkSZJUSAZiSZIkSVIhNSsQR8RWEfFIRDwbEc9E\nxLfz5T0iYmpEzIyIByOiqnWbK0mSJEmqJG05Pza3h3gl8J2U0g7AbsApEbE9cDYwNaU0CHgofy1J\nkiRJKq42mx+bFYhTSnNTSk/lz98Bnge2AA4BJuWbTQJGtkYjJUmSJEmVqS3nxxZfQxwRA4BdgL8C\nfVJK8/JV84A+La1fkiRJkvTx0NbyY4sCcUR0Ae4ETk8pLS1fl1JKQGpJ/ZIkSZKkj4e2mB87NLdg\nRGxEdjC/SindnS+eFxGbp5TmRkRf4M36yo4bN670fPjw4QwfPry5zZAkSZIkbUDTpk1j2rRpDW7T\nkvy4PjUrEEdEADcCz6WUJpStugc4Drgs/3l3PcVrBWJJkiRJUuWq28l58cUX11rf0vy4PjW3h3gP\n4Gjg6Yh4Ml92DvAjYHJEnADUAEe0uIWSJEmSpErWZvNjswJxSulPrP364/2a3xxJkiRJ0sdJW86P\nLZ5lWpIkSZKkSmQgliRJkiQVkoFYkiRJklRIBmJJkiRJUiEZiCVJkiRJhWQgliRJkiQVkoFYkiRJ\nklRIBmJJkiRJUiEZiCVJkiT9//buPO7Wud7/+OttI2NIVIYiw4kOKZKjTqKUTprTJJST0yQdnYpD\nvxNRthINDk5laqAjJEWSRJNQGTfilHmuKGOG/f798f3eWe49WGvv277Wd6338/Hw2Nd9Xd17f67u\ne611fb7D5xMxlpIQR0RERERExFhKQhwRERERERFjKQlxREREREREjKUkxBERERERETGWkhBHRERE\nRETEWEpCHBEREREREWMpCXFERERERESMpSTEERERERERMZaSEEdERERERMRYSkIcERERERERYykJ\ncURERERERIylJMQRERERERExlpIQR0RERERExFhKQhwRERERERFjKQlxREREREREjKUkxBERERER\nETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERERESMpSTEERERERERMZaSEEdERERERMRYSkIc\nERERERERYykJcURERERERIylJMQRERERERExlpIQR0RERERExFhKQhwRERERERFjKQlxRERERERE\njKUkxBERERERETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERERESMpSTEERERERERMZaSEEdE\nRERERMRYSkIcERERERERYykJcURERERERIylJMQRERERERExlpIQR0RERERExFhKQhwRERERERFj\nKQlxREREREREjKUkxBERERERETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERERESMpSTEERER\nERERMZaSEEdERERERMRYSkIcERERERERYykJcURERERERIylJMQRERERERExlpIQR0RERERExFhK\nQhwRERERERFjKQlxREREREREjKUkxBERERERETGWkhBHRERERETEWEpCHBEREREREWMpCXFERERE\nRESMpSTEERERERERMZaSEEdERERERMRYSkIcERERERERYykJcURERERERIylJMQRERERERExlqY8\nIZa0laQrJF0labep/vsjIiIiIiKiLcOaJ05pQixpGnAwsBWwLvA2SetM5b8xFe67576uQ5gSZ511\nVtchTIncx/AYhXuA3MewyX0Ml9zHcBmF+xiFe4Dcx7DJfQyX+b2PYc4Tp3qGeGPg/2xfY/tB4FvA\na6f435hv992bhHiY5D6GxyjcA+Q+hk3uY7jkPobLKNzHKNwD5D6GTe5juEzBfQxtnjjVCfHKwPU9\nX99Qz0VERERERMR4Gto8caoTYk/x3xcRERERERFtG9o8UfbUxSZpE2Av21vVr/8TmGl7/57/zdD+\nnxERERERERHzz7YmjvvJE7sy1QnxwsDvgJcCNwHnAW+zffmU/SMRERERERHRjGHOExeeyr/M9kOS\ndgZ+CEwDDh+Gm4yIiIiIiIhuDHOeOKUzxBERERERERGtmNIZ4mFU+1u9lkeqmN0AnDwsIxLjSNIi\ntdx677kn2/5jVzFFRMzNKLxHSVoGWBP4g+07uo4n2iRpM+AW27+T9CLgn4DLbJ/ScWgREfNkqqtM\nDxVJuwHH1i/Prf8tBBxbN3I3QdITJC3U8/UWkj4i6ZVdxjUoSZtLugG4RdLpklbvufyjruIaR5KW\nl/QJSe+WtJCkPSWdIumzkpbrOr5+SXqDpOXr8YqSvibpUkn/K2mVruMbhKStJP2rpNUmnd+xm4im\nhqTndR3DoCS9UtLVkn4u6bmSZgDnSrpR0su6jq9fkr4p6cn1+BXAJcD+wEWS3txpcAOS9ERJa8zm\n/PpdxDNVJH266xgGIekLwH7ANyTtA3wGWAzYVdIBnQY3hiQtLOm9kvaV9MJJ1z7eVVxTQdKVXccw\nKElrSDqy/jyWlvQVSTMkfXvyZ3tLJK0l6U2S1u06lsfLSC+ZlnQVsO5sZiMXpYxmrtlNZIORdDGw\nme07JH0UeD1wKrAZ8Bvbu3caYJ8k/RrYAbgMeCMwHdjO9jmSLrD93E4DnA+SzrS9Rddx9EvSD4CL\ngScC61AelL8NbAmsb3soGqU/FkmX216nHh8HnAMcTynYsK3tLbuMr1+S9gNeCPwWeDXwBdtfrNea\neW30JL+itFcQcDLlnrD9245CG4iki4C3AssCpwD/YvtXdcXRMQ39PC61/Y/1+BxK8ZJrapJ8pu0m\nkk9bYCIAAB0CSURBVMmavH8euA1YBHiX7fPqtZZeH1+azentga8Btr3LAg5pYJIuA/4RWBy4EVjZ\n9j2SFgEutP3sTgPsk6QPAt+yfbukNYEjgPUpBX/ebfuSTgPsk6TDKT+L84F3AGfb/nC91tJr4y4e\n+cyYsARwL+W18cROAhuQpJ8Bx1A+O94BHAkcR3m22raV50RJZwFvsv1HSdsB/w/4KfAC4CsTzyej\nZNSXTD9MWSp9zaTzK9VrrVioZ3nbW4EX2b5P0nTgAqCJhBhY1PaMeny8pMuBE+tMfjMkXcKsb9xr\nT5xv5CFzJduvlCTgRtsvqed/WpOBVvSuclnD9sSs11GSdu0ioHn0auC5th+UtBdlFcszgZbuAeDX\nwK+Av/WcexLwuXq8+QKPaN48PLGtRtI9tn8FYPvy+ppphSQtY/svlM+86wHqQ860bkMbyJ7AhrZv\nlrQx8DVJe9g+sevABvR64Gzg9Pq1KJ/pv+4sosHNpHz+PVz/dM/5ll4b77M9MUDxReAg4CTKRMNh\nlAHKFmxsez0ASQcDh0g6EXh7t2EN7EhKEvkx27fU99k/2F79Mb5v2Cxl+1AASe+3PbFq4vA6CNOK\n3i1CHwL+yfafJC1BWW2bhLgx/w6cIen/qA8CwKrAWsDOnUU1uLskrVdHLG+njAbeRxkpb+kD6AFJ\nT7V9C4DtGZJeSpmBmWUp3BC7GrgL2JcyeingZ8DWtPPzkKQnAUsBS0pa3fbVdeZokY5jG8TZkj5J\nWcJ3lqQ32D5R0ubAnR3HNohpEytZbN8p6dXAlymz9ot2GtlgtqF8eH7W9qkAkq623UoiPOEvkt4D\nLAPcUQdXjgNeBtzdaWSD2Rv4SX1Q/gVwnKTvAS8BTusysAFNs30zgO3z6uv7+5JW7TiuQa0L7ANs\nBfyH7ZskfcL20R3HNYhTKZ93iwGHU36nfkVJJH/aZWAD6h0QWsH2d+rxWZKW7iKgefT3z+v6GbKT\npE8AP6Z8vjfB9i6SNgKOkfRd4OCuY5pHMyX9A+WzY3FJz7d9vqS1aGub6oOSVrF9A+V59956/m+0\ndR99G+kl0wB1FHxjykyxKUt8fm37oU4DG0DdI/V1yhJXAy+ifPCsBxxo+5sdhtc3SVsCt9u+cNL5\nZYGdbe/bTWSDk/QGyuzdAba/Wx/6mxnJlPQ2yhJEAe8H3lsvrQvsbft/uoptEHX7w57Au+qpVShv\n3N8DdrN9XVexDULSKcBnbJ896fy+wB62m/kAqg+T+1Decz8CnNXSawNA0tOBj1NmvfaizLbsCFxH\nSWSaKcpYH8R2ogwEL0IZHD7J9g87DWwAkn5J2V7z+55zTwS+A/yz7ZYGjZC0IXAAJbnc2fYzOg5p\nIJI2payGOqcuN349cC1wvO2Z3UbXH0mforxHfZIyS38fcCKwBfBG21t3GF7fJH0T+IbtH0w6/27g\nUNstDXBPPLPvDLwJWNP20zoOaSB1kudQymfHTpTnxPUpCfJOtk/qMLy+SXoJ8N/ACZRVXs+jrGx5\nEXBaz8z3yBj5hHhUqDSzfjmPfqg5PZVCuyNpKcqD/zOBjWyv/BjfMlTq75TqMt1FgOcAN9m+qePQ\n5kkdWFkY+JMbe2OTtDiA7ftmc21ilLYpdT/xgcCzba/QdTzRLkkbAPfYvmrS+UWBN9v+RjeRzTuV\nQpnvBzax/Y6u45kfklawfXvXcQxK0rsog8FrAE+gdCE5CZhetxlERyStBGwwsdKoZZJWAO5oaSIO\n/v5M9XYenXd81/YVnQb2OElCHENB0g9sN1U1e0J9WNvE9mFdxzI/6n6XQ7qOY17UpVarUva1Xdni\nG3bdM7URZZa72fvoVe9padt/7TqWQdQVIGfXPVMrUmbzngfMoMwQNzFAUZOubSizFRPF5l4LXA4c\n1sps3iiTtKHt33QdR79UulscQllttwtl9dpilITynbbP6DC8sVdrTzwXmNHa50dNwLbi0W1Sf2i7\npe1PE+3tXsmjV6Y2dx/jJglxAyRtZfu0erwspUDNxpTKwLvavrXL+PpVl4nN7hdOwCm2n7qAQ5ov\narifsqT/mM3pPYBPAdg+cMFGNG9U+mF+jrJfeEPgl5TCHA9SllheP5dvHxojdB/LU5a73Uip2vqf\nwKaUyvKfbmVFi0anevmhwAqUfeh/pSQu36XUO7jF9oc6DK9vku6gLN07llIdu8kHF82+Cvt3gddA\nG1XYNToV2F9DWWV3f9exzA9JJ9l+XT1+LWUr1FmUomD72T6yw/D6Jml74BOUFpwTA46rUqoz793K\nPvtRuY+5kfRl2//WdRxTLQlxA9RTOl+lxP7NwFcp+3Y2m3gzHHaSHmbORTc2sb34goxnXtWCLl+n\nFDf7DfAe21fXa020OZB0N+Vh5rKJU5RiSJ8HsL13R6ENRNKFwJYurTNWBw6y/bq6X/2jtl/ecYh9\nGaH7GJV2Xr+z/Q/1+De2N+y5dpHt53QXXf9U2y7VLRG3Ak+z/be6XeIC1+q0w07S74AvUZbvrUb5\nnTrWtfp3KyTNZNYq7JvUc7RQfE7Sb20/rx5fb3vVnmsX2t6gu+j6J+k+Sr2JUykDLT+03VL3EWCW\n58NzgLf7kQKZLbVWu5JSMfvOSeeXA86zvVY3kQ1mhO7jSXO6BFzc2hbBfox6lelRtBFlX4WBgyS9\ns+N4BnEFJXmcpdm6pCZmwKrPAq/gkX7KP5K0ne1zug1rIOtS9ncuCexl+15JO7SSCPdYqGfv2nXA\nMwBs/0jSF7oLa2Cjch+j0s7rbI1G9fKHoFSflXS+7b/Vrx+qyVkr7rV9MHCwpGdQZigPqQ+Zx9re\no9vw+jYKVdhHpQL7FZQCWttQiv8dpdKu6FhPKm7YkEUnBuddWqu19Bqfk1GZtWvtPv5IKZQ3OyNZ\nEyQJcRtWkPRhysjMMpOutdLmB0q11jlVy91lAcYxv5rvp+xSfflNkl5HaU12UNcxzaPf1FUTP6Es\nO/wJgKQlaas1wKjchzQa7bx2plQv/139eldJE9XLt+ssqsHdImkp23fbfsXESUlP49GzlM2wfS2w\nP7C/pGcBb+k4pL7ZPkHS6cA+taDTR7qOaR7swCMV2F9OmbX/IWUgb6cO4xpY3cLxZeDL9TXxZsrv\n1cq9M99Dbn1Jd9XjxSQ9zaVf9xNo67PjU5TPwdN59FLjl1OKl7ZiVO7jD8BL6/vtozQ2gdW3LJlu\ngKS9ePTo0qG2b6tv4Pvb3r6byOaPpH+m7oW2fXrX8fRL0q+BrV37Kddzq1D7Kdtupvcf/L1a9l6U\nZT4v7jicgahUmd2Jsjz3IuAI2w+rVG1+iu1ruoyvXyN0HyPRzquXGq5ePid1oGWphupPHGj7w13H\nMZWUKuydmtv2JkmrtfKeOyf1fWtd27/sOpZ+1cHUVwAr1VM3UvZ5/7m7qAY3CvchaWfg557UJrVe\n28X2FzsI63GVhLgRtWDFysCvbN/dc/6VntR/blhJOs/2xvV4J+ADlD6SLwe+b3u/LuPrl0aon3LE\nVNOs7bw2oCyfbqadl6T1bV/cdRxTTaVH9FrAHybvcYsFT6UK+NJurMWPpIlKwD/uTRwl7Wj7iM4C\nG4CkzW3/pOs4YrSpVJxeC/h9K0Ulx1VLyynGlqRdKL3xdgZm1GWuEz7dTVTzpHfJ5HsoRYT2piTE\n23YT0uBs/2h2o2a272wlGZa0rKTpkq6QdIekP9fj6TWxb8Ko3Mfc1EJVLZlJaRsFZaZ4JtBaJdcL\nJF0laR9J63YdzLySdEjP8YsobaM+B1wq6VWdBTYPJG0l6TBJ36v/HVYTs2bZnjmRDEv6r67j6Yek\n/SgdCdYDflyfTyZ8sJuoBjcOybCkS7qOoV+S1pH0A0mnSFpD0lGS7pR0Xp0QaoKkb6r0HUbSKyiF\nJacDF0l6c6fBDUjSEyWtMZvzTRRqG1T2ELfh34ANbd8taTXKvtXVbH++27AGNq0uJREwbaKIkO17\nJDXTsLwmWrsDrwOeQlnOfhtl0GJ6IzMvxwE/Bl4C3GrbdQn+DvVaE1WNGZH70CPtWGa5ROkp2YQ6\nWPc/wExJ76U8ON8NPEvS+2yf3GmA/buYslf47cDJdf/wMcC3GltK+U89x/sCr7P9W5Vepd+mbPMY\neiqF5dYCvkZZfgilX/cukv7Fdks1KOZkJ+CTXQfRh1cDz60rQPYCjq2/T7t2G9Zgemez65anoykt\n7y6j9FOepfjnMJL0xtmcnmjp9bQFHM78+DLwGUr9iZ8AuwE7Aq8CDqa0vGvBc3oKZO4FvNj2NbWO\nxpmU55KhV5P3zwO31ZVe77J9Xr18NA09l/QrS6YbIGmG7Wf3fL0UpSfjZcDmDbU5uIZH9kIbeGEt\n/rA08LOG7uN0ShJ2NLMmYVu4gRY5kq60vfag14bNCN3HqLQkuxDYCliCshf6+bavUKkMfKJ72hcN\ns8n7CyW9gFLZeBvgOtubdhbcAPToliyT76mJFnEAkq6aXbsSSQKusr1mB2ENTI8UP5qdxW0P/SSF\nenp0168XpiQzTwTW6X1WGWaTXhvfpvSNPZxS1HBn200kYJIepAzWTa4oLeBNrdQ0mfTz+L/e13Rj\n71UzgE1t/0XSzymtUR+euNbQ6+MiYKv6jL4xZTByj9ptoZmfxyCG/s03gDJCs8HEMt06U7w15c27\nmaULtlebw6WHKT2VW7Ga7f17T9i+GZguaceOYhrUtZI+Bhw9UVhH0lMpSf11nUY2mFG5j1FpSeaJ\nYnOSrrN9RT15bd0v2STb5wLnSvoPoKXCc8/qWTa5uqTlbN8haRptVf2+X9LGPTMUEzYG7usioHl0\nB6V44S2TLzT0Ov+DpM1cWxPZfgjYUdK+wBu6DW2e/YPtberxdyR9otNoBnMJcIDtWZZHS2oiqa+m\n9RwfOOlaS+9VewM/kXQw8AvgOEnfo6xiO63LwAY0rT7XYvs8lZaD35fUSvX1gSUhbsP2wIO9J+py\npR0oI7NNs30vcHXXcQxgFJKwt1CWfZ8t6Sn13K3AyZTWE60YlfvYi9FoSYakhWzPBN7Vc25h2nqo\nOWB2J+t9nbVgQ5kvk/fe3VP/XA5oYs9q9U7g0LqaaKKVySrAX+u1VnwdeDowS0IMHLuAY5lX2zCb\nnqq2Py7psA7imVerSPoiZSb1yZIWsT3xnNXSs/G/U14Hs9PSAMUhkpa2fZft3toHawJndBjXQGwf\nJ+kCyhaItSifey+g9Lf+YafBDeavktaw/Xsokz41Kf4O0MQs96CyZDpiQHUf9O6UpVWTk7DprZTW\n1yOVy8+1fVfP+a1stzSS+SiSvm67pV6xqPSMfCulGvMZkrYFNqVsi/iK7Qc6DbBPdWnVJbbvm3R+\nNeBFtr/RRVwxGurWlJXrlzdOzGBEtyS9vzeJaYGkd/LIXlsD37P95/o79kHbe3QZX0SXJG0A3GP7\nqknnFwXePIqf5UmII6aQpHfZPrLrOB6LSmXQDwCXU4ojfMj2SfVaM/tD6lKkiYeaCVtQilfY9ms6\nCWxAko6hLBlbAriTUljkROBlALZ36C66+SNpedt/6jqOQai0yvhPyizkqbaP6bl2iO33dxbcAHoH\nt2oxwM9Re78Du7qRPsRzI+lZE0vzWzFpNnLi3JNt/7GrmPpVtw1MtgfwKQDbk5e7xuNI0kHACbZ/\n3nUsU03Smba36DqOQUhantIR5kbKtsY9eGRw+9NO66WhlYQ4YgpJut720O+xkHQppVjTROXyE4Cv\n2/58YwnxBZQPmq9SioqIsvTwrQAT+9yGnaRLbK9XlxbfBKxk+6FaNOhi2+t1HGJfJO1P2c92u6SN\nKBU1Z1KWje1g+6wu4+uXpBOBK4FzKZVOHwC2tX1/a6+PnkI1hwM3U14rr6cUe3nd3L6/Ba2850Lp\nfUtZNr048BtK3YCr67Umfq8k3U2pTn7ZxCngQ5SKtLi0Uhx6kxKXIygDYM0lLpJuB64FVgS+RVma\ne0G3UQ2u1jqYPLi9NuV92LabqJej0ibxYmAZypaViykV/bcE1rf92g7D65ukOyjPhccCZ3oMksWW\n9klEDAXNvbffU+ZybZjI9t0ALi0BNgNOUKkGrLl/61DZiPIwtifwUdsXSLq/lUS4h+qy6SUoD8vL\nAH8CFqOt9+lX2d6tHh8AvMX2+ZLWpnywNlFlGljD9sT+u+9I2pPSc7WJh5k52AjYoD7YHFSXjDZB\n0pfmcrmlfuOfBV5BSbreCPxI0na2z+k2rIGsSyl6tCSwl+17Je3QSiLc4xuUZGUj4B2UVRP7UxKX\no4BWXus32N6ovse+FfhGHVg9hpIcN9E+ilJH5i5Ke7h7Kc8hPwO2pq1nkpVsv7IOZt9oe7N6/qe1\ncnMrbgMuBPYBvq5Sif1Y27/qNqzHT0sPWhHDYkVKa5nZjSD/cgHHMq9GpXL5w8CBko6jPOTfRpvv\na4dTlq8vDHycUpnyamAT4H+7DGxA03qWgy5m+3wA21fWvUetWLSnOBi2PyXpRuBsynL2Vqwg6cOU\nB8plJl1r6SHzncBHgL/x6IJOovSKbsWitmfU4+MlXQ6cKGm3uX3TMLF9HfAmlZ7jZ9Qluy2anLi8\npJ5vLXEBynsspY/1JyU9B3gb8ANgjU4D65Pt10h6A6VQ7AG2vyvpIdvXdh3bgFTrzCwFLClpddtX\nq/Qhbqmw5L22DwYOrhMlb6UUPluOkhiP3B77Fh8cI7p2CrDU7JYlSWplZnKkKpfbvgHYpib1f+k6\nnkHZPqgm9di+UdLXKPuHvzybVjPD7BDgVEn7AadJ+gJlL/QWlNHmVnwfeCmlNykAto+SdAswt9nK\nYfNVYOl6fCTwZOD2WhW/pZ/Hr4FLbf9i8gVJey34cObZA5KeOtF2yfYMldY4p9BI4jLB9kmSzqBU\nyG+lZVSvUUlcZmH7Ikof+N27jmUQLj1uTwf2UWlh2dIg6oT9KIPbAv4V+EoZc2FdSkum5tRBif2B\n/SU9i9LdY+RkD3FEREyZuk/yfZSWEwtT2uScBBwxuZDQMJP0AmBmXfL9bMqqkMttn9pxaH2TtAkl\n5r9IWoLygPw8YAawn+07Ow2wTzVxud+lRV+zJG0J3D6xMqfn/LLAzrb37Say8SPpbZR9zwLeD7y3\nXloX2Nv2/3QV2yBUWxV1HcdUq1WON7HdUisv4O9tBlUnGRYBngPcZPumjkPrm6SDbO/adRwLUhLi\niIh43LVSgR3+Puu4FWWm6HRKH8mfUPYXnt5K4iLpMkohl4ckfYXSh/h4yuqD9Xv2SUdHWqvCPioV\n2GE0EhcoU92UvdCrAA8DV7ZWeR1G6j6eDvzV9p21aOnzKQOTl3YaWMxVEuKIiHjcNVYN+FJgA8qS\nvVuBVeos6+LAeQ1V/b7c9jr1+Le2n9dz7SLbz+kuuv6p9Ib9L0rF8v8CPkgpSnU5pWVcE/2I51KF\nfVFg+xaqsI9KBfbZUZv9lDejtFO7k1K08JeUQnMPAtvZbmI5+wjdx+7Aeyivi89Sah/8glIP5Ajb\nn+swvL5JOhA4cRTbec1J9hBHRMSUeIwK7CsusEDm30O2HwIekvR7238BsH2fpJkdxzaIGZJ2tH0E\ncJGk5/dU/X6g6+AGcBRlX/dSwFnAN4FXUSoBH0Y7FYFHoQr7SFRg1xz6KUtaDJrqp/wFYMs6yLI6\ncJDtF9bl+YcDL+82vL6Nyn1sT1l2vyRwDbB6vaclgfMoSX8LtgNeLKnpdl6DSEIcERFTZRQqsAP8\nTdISdc9q76zqspSlfK14N/AFSR8Hbgd+KekGShGkd3ca2WBWtP0lAEnvsz29nv+SpJbuYxSqsI9K\nBfa9mbWf8kI8UoSuFQvZvr0eXwc8A8D2j2pRw1aMyn08VAdOH6C0j/ozgO17JLW0JHdU2nn1LQlx\nRERMlVGowA6wme37ASYe/KuFgR26CWlwtWjWDnXf5+rUImcTVY4bslDP8dfncm3YjUIV9lGpwD4q\n/ZR/I+lwSo2D19Q/qTOSLb02RuU+LpB0LOX36kzgaEmnUV7jl831O4dQ6+28BpE9xBERETG0JO0D\nfGZyNV1Ja1GqZb+pm8gGV6uwvxdYm4arsE+Q9M/AxsAltk/vOp5BqfRT/hhwEOV3bPWOQxpIXVmw\nE7AOpdXSEbYfrvUOnmL7mi7j69cI3cciwDaU2gDHUwoyvh24Fvhv2/d0GF7fWq8HMC+SEEdEREST\nevZIN0HSOsDKwLm9Cb6krWyf1l1k/ZF0nu2N6/FOwAeA71D2eH7f9n5dxjcvJC1F6ae8se0XdxxO\nROdGtZ3X3LS0DCEiIiKiVzNLXCXtQpkN3hm4tM5OTmglkVyk5/g9lEJIe1MS4m27CWn+2L7b9kda\nTIYlLStpuqQrJN0h6c/1eHqtedA8ST/oOoZ+SXqapEMl/bek5SXtJekSScfVavmtaGqlxFTIHuKI\niIgYWo9RvfwpCyyQ+fdvwIa27679SY+XtJrtz3cb1kCmSXoSpQjVtIlCSLVo0EPdhta/mizuDryO\n8jtk4DbKgMX0uv++BccBPwZeAtxq2zXx2qFea6I6s6TnzekS0NLS3aMYjYr4F0j6A49UmG5u//Og\nsmQ6IiIihpakW5lL9XLbKy3gkOaJpBm2n93z9VLACZRiO5vb3qCz4Pok6RpK8kj984W2b5a0NPCz\nFu4BQNLplETyaGZNJLew3UoieaXttQe9NmwkPQz8dA6XN7G9+IKMZ1717r2VdJ3tp/dca6n3+wWU\n1ktvB95MqZh9DPCtVvZzDyozxBERETHMRqV6+W2SNrB9IZSlupK2pvRZXb/b0Ppje7U5XHoYeP0C\nDGV+rWZ7/94Ttm8GpkvasaOY5sW1kj4GHG37VgBJT6Uk9td1GtlgrgDeM7t2PpKu7yCeeTUqFfGx\nfSmwB6U/9wso7Zd+XhP9TbuNbuo19cOJiIiI8WJ7R9s/m8O1ty3oeObD9sCjWl7VytI7AM3tX+1l\n+17bV3cdxwCulfQxSX9fci/pqZJ2o61E8i3Ak4Gz6x7iOyhLdZenzOy1Yi/mnJPssgDjmF8n15Uf\n2N5z4qSkNYHfdRbVfLJ9ru1dgadTkuSRkyXTERERETE26j7o3Sk9byeS4luBkyl7iP/cVWyDar1y\n+ZxI+prt7buOYxCSnkCZSb3R9hmStgU2pWyL+IrtBzoNsE+StrX9za7jWJCSEEdEREREAJLeZfvI\nruPoR61c/gHgckrxqQ/ZPqlea6aXrKTvUfakq+f0FsCZgG2/ppPABiTpGGAasARwJ6W41onAywBs\n79BddPNH0vK2/9R1HI+X7CGOiIiIiCg+CTSREDNr5fITGqxcDrAKZRb1q8BMSmK8EXBAl0HNg/Vs\nrydpYeAmYCXbD0n6BnBxx7H1TdJ04HO2b5e0EaVi+UxJiwLb2z6r0wAfB0mIIyIiImJsjFArL9m+\nG8D2NZI2oyTFz+DRs63DbiPgQ8CewEdtXyDpftstFc0DUF02vQSwOLAM8CdgMdrKuba2vXs9PgB4\ni+3zJa0NHAts2F1oj4+WfjgREREREfNrRebSymsBxzI/mq9cDmD7YeBASccBB0m6jTZzlMMpy9cX\nBj4OHCfpamAT4H+7DGxA0yQtUov+LWb7fADbV9ZZ4pGTPcQRERERMTYkHQEcObvq5ZKObaV6uaRV\ngQdt3zLpvCg9on/eTWTzpyb1m9purqKxpJUBbN8oaTnK/uFrbZ/XbWT9k/RBSsG5/SgV8Jej7IXe\nAnim7e06DO9xkYQ4IiIiIiIiAJC0OfA+YC3KjPcNwEnAEXXmeKQkIY6IiIiIiIi5aqkK+yCSEEdE\nRERERMRcSbre9qpdxzHVWtywHhEREREREVPsMaqwr7jAAlmAkhBHREREREQEjE4V9r4lIY6IiIiI\niAiAU4ClbF8w+YKk1npD9yV7iCMiIiIiImIsLdR1ABERERERERFdSEIcERERERERYykJcURERERE\nRIylJMQRERERERExlpIQR0RERERExFj6/zRscM7UJZA/AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f17f2eb3c50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The probability that the distributions for payload/histograms/GECKO_THREAD_ACTIVITY_MS (absolute) are differing by chance is 0.00.\n"
+     ]
+    }
+   ],
+   "source": [
+    "compare_thread_activity(subset, \"Gecko\", 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Parent main thread activity with buckets below 128-255ms ignored completely"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7kAAAHZCAYAAABDzPyzAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3XucVXW9//HXBxAFucwggqAiKoGieSkl09TRvJCWUqRC\neT12yGtaWd4Vj55Q0yN5OpqVF1LTMNO8ZMpR0TqnUkrxiBroz1FDREBuilyS7++PtWa7ZxiYPTA4\nM8vX8/HYD/Zea32/67vWsPdjv/f3u74rUkpIkiRJklQEHVq7AZIkSZIktRRDriRJkiSpMAy5kiRJ\nkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5ktqNiLglIi5dD/XWRMQba1hfGxGfX826vSPi\npZZuk6S2IyIOjoh7WrsdTYmIgRGxMiI65K9/FxHHtPA+xkbErfnzvhHxQkR0bsl9SNK6MuRKak9S\n/ljvIqJ/WfBd7X5TSn9IKW1XQX2lL4ZFEBHnRsS/58+7R8R/RMSrEfFuRLwWEXdFxLCy7Vfm6xaX\nPc4qWz84LzMnIhZExNSI+HZEdGjki3tExH9GxIsR0S9//b2ImB4RS/L9/6CpL94R8VBZW5ZHxLKy\n19et7sePiJgcESfmz2vyti2OiEUR8VJEHN9g+zUee77N8fl2RzZYXl7/4oh4IyJ+FRG7NeNvFRHx\n/yJi2mrWfSsi/i9v4xsRMTEidmzO+YmIn0TEhEbq3zkilkZEdd17ICK2bHA+Gp6fCxoGp4jYJCLe\njoiD1nCcdefqN420YWVEPF627PCIeDYiFub/5x6NiIFrOI3/Doxb03lui1JKh6SUWvpzp/RZmFKa\nDTwOjGnhfUjSOjHkSmpv4iPazyHAQx/RvtZJRHRqhd0eAjwYERsCjwE7AIcC3YHtgTuBLzQos1NK\nqXvZ4yqAiNgW+AvwGrBjSqkKOAL4NNCtvII86N4A7APsk1KaBVwL/CtwTL79F4DPAxPXdAAppS/U\ntQW4HbiirG2nrKko9X/0mJmX6QF8G/hZRAyu5NjLHAe8AxzbyP5mlrVzD+Al4A8Rsf+ajq/MPsCm\nwNaNhOMfAd8CTgeqgcHAvcChzTw/twBfiYiuDZYfA9yfUppftyCl9EZKqVtZ3VD//FwGzAQuKqtn\nPPBASumRJo51DrBHRPQqW3YcMJ38bxYRg4AJwLdTSj2BrYH/Aj5orMKI2B3okVJ6qol9N1srvXdb\n2u3AN1u7EZJUzpArqcVFNrz3nIiYFhHvRMRNeRgiIqoi4oG8V+adiLg/IjbP1x0REVMa1PWdiLh3\nNfv514iYERHzIuK3EdGvbN2PIuL1vKdmSkR8rmxdl8iGPr+T927t3kj1hwC/K3u9a2S9iwsi4s6y\n46nX2xcRZ0fEP+LDXr39I2I4cC5wVN5T9Uy+bf+IuC9v/4yI+EaDNk7I2/hCRHy/wX5q82XPAYsj\nomN+zl/O9z0tIkaUbX98RPxPZD2u8yPilYj4bL789YiYHRHHlm1/SF7Hovx4vlu2ri4M/YksxGwO\njEgpvZAyS1JKd6eULmns79aIS4A/ppTOynuGSClNTykdnVJaVLZdJ+Bm4FNATUppTkR8AjgZ+FpK\n6S8ppZUppReAkcDwiNivwjZAC/yAklJ6iCysfrLinUZsRRZE/xU4OCL6rqH+mSmli4GfA1dUuIvj\ngN+S/WhzXNl+PwGcAoxKKU1OKa1IKb2fUvplSqmxuld7flJKfyYLpiPL6u8IjAZ+UWE7y30DOCXv\nhT0Y2J/sB4SmLCcL6aPK2nAkWRCra/8uwKsppcfztr+bUvpNSml1lyx8AZhcviDvGf5mZKMH5kfE\nj8vWRWS90bX5+2pCRPTI19WNSviXiHgNeDQijmvme/PQiHgm/2x7PSIuXt3JiPqjDqZG/dEEKyNi\nn3zdHhHxv/n+n42Ifcvq2Doinsg/Cx4BejfYzVPANhGx5eraIUkfNUOupPXla8BBwLZkgeiCfHkH\n4EZgQP54H6j7gngfWW9T+fDfY8h6XeqJrBfrB2Q9fv3IegHvLNvkKWBnst6pXwJ3xYfDHy8m673Z\nBjiY7It/qWcuIjYA9gYm1S3K93NwXm4n4PhG2jQEOBXYLe/VOwioTSn9Pm/rnXlP1a55kTuB1/P2\nfxX4QVkouzg/P1sDBwJHs+qQ6VFkX8CrUkofAC8Dn8v3fQlwW4PANAyYCvTKz8mvyHpLt83r/3F8\n2BN3IzAmr2sHst7aOgcD/51SSsABwO9TSu83PB+NWF1I+jzw6wrK/xL4BLB/Wc/g54E3Ukr1fhxJ\nKf0D+DPZuftIRDa0+jCyEPByw9VrKHos8HRK6R7gReDrFezuHuBTEdGliTZ1JQuet5EFvVHxYe9h\no+duHfyC+j3RBwAbUP/HooqklF4j68m9GbgeODmltLDC4reWteNg4HngzbL1fwO2y0NlTUR0a1hB\nAzsCf29k+aHAbmSfB0fmYRzgBLLPlBqyz5hufPgZV2cfYLu8fUHz3pvvAkfnvdCHAidHxOGraXtp\n1EFKaeey3vPvko0I+FtkPzI+APxbSqkaOAu4OyI2yev4JfA0sAlwKQ0+L1NK/yT7/77LatogSR85\nQ66k9SEBP857neaTXc82GiCl9E5K6Z6U0tKU0rtk4W/ffN0ysi93RwNExA7AVmRfwMrrhiwI3JhS\nejaltJysp/SzETEgr+v2lNL8vGfvP4ANgSF52SOAf08pLcjD0I+oH0L2AaamlN4r2+e1KaW38uO5\nn8a/0H2Q72eHiNggpfR6Sun/5euifB95r8eewNkppeUppalkvXN1X86PAH6QUlqYUprZSBvr2jQz\nP2+klH6dUnorfz4RmAF8pqzMqymlCXk4nQhsQfbFdkVKaRJZL9igfNvl+XH0yNvwTFk9h/JhcNkE\neKvsuHbJe4MWxqoTcv0tX1f3OLCsjlmNnM+GDgB+3aB3t3f5/huYlde9Lvo3aPN84HONbQMsAX5D\nNgx2aoNtVnfskP3Nf5k//yWND1lu6E2y/w9VTWz3FWAp8AjwIFno/GK+rt7frgXcBuwbEf3z18cC\nt+c/wDRbSunHZP8Pn0kp3deMcn8CekU2ZPxYGvxIlr8na8hGIEwE5kTEzRGx8WqqrAIWN7L88pTS\norwH+HGyH9Ug+2y6OqVUm3+GnEv240L5d66xea/50vx1xe/NlNITKaVp+fP/I/uxbF8qFNmolkuB\nw/LP4KOB3+U/xpFS+m9gCnBo/nm6G3Bh3pY/kH3+NfzRZjHQs9I2SNL6ZsiVtL6UD/17HegPWc9S\nRNyQD+VbCDwB9IyIui9NE8h6gSHrxf1VSmlFI/XX9d4CkH+ZnEf2xZWIOCuyYb4L8gDSkw+H2fVv\npH3lDiELBOXKw8D7NLhWNG/Dy8CZwFhgdkTcEWVDqBvoD7xTFqTr2tG/bH15G//RSB31hldGxLH5\nMMa6MLYj9UPe7AbHQEppzmqOayTZeajNhzzuke+jA3nvbb7dvLI2k//oUE0WrjZs0N5dU0rVZY9J\njdWxBl8ELo6IE8qWzSX7v9CY/vn6dfFmgzZXA39sbBugB9n1wY3NxN3osUfEXsBAsh93AO4APhkR\nOzdSR7nNyX7oWNDEdscBd+U/9iwjC+F1Q5bnsfpz12wppdeBJ4Fj8t7Rw1m7ocrlXgRWmTCrAreS\nXWdcQ9brXS+U5UPbj0op9SEbtbEPcP5q6ppP9rdtqPwzYQkfvnfqfTaRva87AeWjKhoOja74vRkR\nn4mIxyO75GMB2fWwFf2Yk/+49ivg2PzzCrIfEo9o8EPOXsBmZO+h+Q1GarzGqrrT9P9FSfrIGHIl\nrS8DGjyfmT//Ltnw5WH5cLt9KevlTCn9BVieXys2muzLamPeJAsHAOS9MJsAMyNib+B7wBEppao8\ngCzkwy+6sxppX7kvsBZDLPP235FS2pvsi2Piw+smGw41fpOst6k8LJefp1lA+TVujV3vVj7Eeivg\np2TDpXvlx/w8a3mdaUppSkppBNmERffy4SROuwOvpZTm5a8fBQ6KVSccas5+/5uyaznX4H+BLwE/\niojRZfvfMrLJgT7cefZl/jP5+o9EPqLgbLKQurrhow0dR3auno2IWWRDrOuWr8mXgb+uaZh4RGxB\ndi3r0RExK69/JHBIPhT1UWCLiPh0hW2txASyH6dGkvVOlo8AWNuZ0dfm//BtZNdqP1jWW9qofLj2\nPWQ/CjXmObLPrErV+2wie1//k/pBdl1mif8l2Xtyi5RN0vYTKvg+lw9tvxe4JqX0cNmq14FbG/wI\n0z2ldCXZ51B1g/d33WdbXb2dyHqZG45ekKRWY8iVtD4E2aQxm0c2y+n5fNhT1Y2sV2Jhvq6xSVN+\nQXYN2/KU0v82qLfuC+8dwAmRTUyzIdmw5z/nvUndyb5Uzo2IzhFxEfV7YiYC50Y2CdYWZD0+2Q4i\ntgY2TCk1dg3emg86uw3O/nl7lpENE60bqvkWMLCuxzof4vi/wLiI2DAidgL+hezLecM2bg6cxpq/\nGG+cr58LdMh7O1f3pb2p49ggIr4eET3zoaaLy47jEOoPH/8F2RfheyJih8gmwNqIbIhjw/auLqxc\nDOwZEVfWXUMcEYMiu91MvR60lNKTZL3EP42Ir6SUZpB9yb897+HqmA9zvxuYlFJ6jMq0yKzd+aiD\nq6k/M3Cj9efn6UiyCad2LnucDnwtskmTyreP/D11MXAicF4TzTmG7LrLwWV1DyYbFTA6P3fXAXdE\nxL75e2WjiBgVEWc31f7VuJss1I0lm3F5bepY1zKklF5lNb2zEfG5iPhGRGyav96O7MeTP62mut/R\n9HDghp9N345skqlufHg9/srmH0mjupH1ri6P7DZdX6Oy0HwT8GJadWbv24AvRcRBde/fyK5V3jxl\n10ZPAS7JPxc+x4fD3esMI5t7YLX3Gpekj5ohV9L6kMh6Gx4BXiG7NvSyfN14oAtZGPtfshlfG35B\nu5VssqPbGiwvn0TlUeBCsi/Vb5JN0DQq3+73+WM6UEsWqsuHJF9CNuTu1Xy7X5S14VBWHarc2PGl\nBq8hG547juw2JrPIhkefm6+7K/93Xnw4g/Rosh6fN8mGkV5UFsr+jSyMvEp2Hu8iuy6v8QZlMwpf\nTfZF/S2ygFs+rLaxe/2u6Yvx0cCr+ZDyMXw4GVK9WafzIbD7AS+QnbeFZMHq02QBrlzD2V3/I6/j\n/wGfzc/FtHwI5q/JJrt5t2Fb82sGjwImRMShZD8A/Jzs/8tisv9Tj1FZ73CpWho/H5WEh4bb3AQM\nyNtWp7FjPxx4D/hFSuntugfZZEudyCYlSmTX/C7Oj+0psvfGvvl5WJNjgevK607Z7NU/ydeRUvoW\n2Q9K/0U2LPflvF0Nr4Gt6PyklJaQvSc3J5voqtl1VFhmTdvXteV/665Rb1DPfOAw4P/y8/oQ2fvv\nykYrzHqjF0bZfZ8baVN5/TeRfYY9Cfw/sqHMpzfYdnVlV7dNuVOAf4uIRWSfgb9qsH51ZY8CRjT4\nf7hXyuYlOJzsR5O3yT4rv8uH3xG/RjYq4h2yH28aTgT4dbLJwSSpzYhsjgNJajkR8SpwYjN60RqW\n70I2tG/XlNIrLdq4pvf9IPCfdZOwtBURcTJwZEqpObfEaek29AX+llLavLXaILWGyCYKOyWl9OXW\nbktbEhF9yG6vtEs+XF+S2gR7ciW1RScDT33UATc3mQb3xGwNEbFZROwV2W1phgDfIbtusDX1yNsh\nfayklCYZcFeVjw4YasCV1NZ0anoTSfroREQt2XC7Ea2x/5TSD1tjv43oTDasdGuyWUvvILt+stXk\n13DOaM02rI2ImMaqk4tBdh/gOz7q9rSkfJK1xiZJSym7x3GhRMR5fHgJQLknU0qHNrJckvQx5HBl\nSZIkSVJhOFxZkiRJklQY63W4ckTYTSxJkiRJBZZSapFb8bWU9d6Tm1Jq9cfFF1/c6m3wmDymIjyK\ndjweU/t5eEzt41G0Yyra8XhM7efhMbWPR9GOaW2Ppy1yuLIkSZIkqTAMuZIkSZKkwvhYhNyamprW\nbkKL85jah6IdU9GOBzym9sJjah+KdkxFOx7wmNoLj6l9KNoxFel41usthCIitdVx2pIkSZKkdRMR\npDY28dR6nV15bZx55lgWLGjZOquqYPz4sS1bqSRJktq1iDb1vVxq89pLB2abC7kLFsDAgWNbtM7a\n2patT5IkScXQXr60S62tPf0o9LG4JleSJEmS9PFgyJUkSZIkFYYhV5IkSZJUGIZcSZIkSas1evRo\nfvvb37Z2M9qd2tpaOnTowMqVK1u7KR87bW7iKUmSJKm1nHnOmSxY2sK3+ihTtVEV4y8fv871PP/8\n83z3u9/lb3/7G/PmzVslSL3zzjuceOKJTJo0id69ezNu3DhGjx7d7P0899xzPPfcc9xxxx0APP74\n45xxxhm88cYbdOzYkX322Ycf//jH9O/fv7Tfk08+mUcffZSI4OCDD+b666+ne/fuANx///2ce+65\nvPbaa+y00078/Oc/Z/vttwfglltu4cQTT6Rr166l/T/44IPss88+QBYaTznlFP785z+z4YYb8tWv\nfpXx48fTsWPH5p9AFZohV5IkScotWLqAgSMGrrf6a++tbZF6OnfuzKhRozj11FMZMWLEKutPPfVU\nNtpoI95++22eeeYZDj30UHbeeWeGDh3arP3ccMMNHH300aXXO+ywAw899BCbb745K1as4IILLuDk\nk08u9fRecMEFLFy4kNraWlauXMnIkSMZO3YsV199NTNmzODoo4/moYceYo899uDKK6/ksMMO46WX\nXioF1b322osnn3yy0baccsop9O3bl7feeov58+dz4IEHct1113H66ac365hUfA5XliRJktqgN998\nk5EjR9KnTx+22WYb/vM//7O0bvDgwZxwwgmNhtb33nuP3/zmN1x66aV07dqVvfbai8MPP5xbb70V\ngLlz5/LFL36R6upqNtlkE/bZZ5/V3krp97//Pfvuu2/pdZ8+fdh8880BWLlyJR06dOCVV14pra+t\nrWXEiBF069aNHj16MGLECKZNmwbAww8/zN57782ee+5Jhw4dOPvss5k5c2a9ULumWzrV1tZy1FFH\n0blzZ/r27cvw4cNLdTf08ssvs++++1JVVcWmm27KqFGjSuvOOOMMBgwYQM+ePdltt9344x//WFo3\nduxYjjjiCI455hh69OjBTjvtxIwZMxg3bhx9+/ZlwIABTJo0qbR9TU0N5557Lp/5zGfo2bMnI0aM\nYP78+Y22aeHChZx44on079+fLbbYggsvvLDUA7+m9qr5DLmSJElSG7Ny5Uq+9KUvseuuu/Lmm2/y\n6KOPMn78eB555JEmy06fPp1OnToxaNCg0rKdd965FAivvvpqttxyS+bOncvbb7/NuHHjGr0H6nvv\nvcerr77KkCFD6i1//fXXqa6upmvXrlx99dV8//vfL6079dRTuf/++1mwYAHz58/n7rvv5pBDDgGy\n+6yWh9iVK1eSUuL5558vLXvmmWfYdNNNGTJkCJdddhkffPBBad2ZZ57JnXfeyfvvv8/MmTN56KGH\n+MIXvtDoObjwwgsZPnw4CxYsYObMmXzrW98qrRs2bBhTp05l/vz5fO1rX+OII45g+fLlpfUPPPAA\nxx57LPPnz2fXXXfl4IMPBrIfHS666CK++c1v1tvXrbfeys0338ysWbPo1KlTvX2VO/744+ncuTOv\nvPIKzzzzDI888gg///nPm2yvms+QK0mSJLUxTz/9NHPnzuWCCy6gU6dObL311nzjG9/gzjvvbLLs\nu+++S48ePeot6969O4sXLwayoc6zZs2itraWjh07stdeezVaz4IFC0plyw0YMID58+czd+5cLrvs\nsnoheNddd2X58uVssskm9O7dmw022ICTTz4ZgAMOOIAnnniCJ554guXLl/ODH/yA5cuXs2TJEgD2\n3Xdfpk2bxpw5c7j77ru54447+OEPf1iqe++99+b555+nR48ebLnlluy+++4cfvjhjba9c+fO1NbW\nMnPmTDp37syee+5ZWvf1r3+d6upqOnTowHe+8x2WLVvG3//+99L6ffbZhwMPPJCOHTvy1a9+lTlz\n5nDOOefQsWNHjjrqKGpra1m0aBGQBfdjjz2WoUOH0rVrVy699FImTpy4So/07Nmzeeihh7jmmmvo\n0qULm266aSm0N9VeNZ8hV5IkSWpjXnvtNd58802qq6tLj3HjxvH22283WbZbt26lEFZn4cKFpbD6\nve99j0GDBnHQQQex7bbbcsUVVzRaT1VVFUApHDdUXV3Ncccdx+GHH14adnvkkUcyZMgQ3n33XRYt\nWsQ222xTuqZ3yJAhTJgwgdNOO43+/fszb948hg4dyhZbbAHA1ltvzVZbbQXAjjvuyEUXXcSvf/1r\nIOv1HT58OCNHjmTJkiXMnTuXd955h7PPPrvRtl155ZWklBg2bBg77rgjN998c2ndVVddxdChQ6mq\nqqK6upqFCxcyd+7c0vo+ffqUnnfp0oXevXuXerq7dOkCZD8k1Nlyyy1LzwcMGMCKFSvq1QfZ33PF\nihX069ev9Pc86aSTmDNnTpPtVfM58ZQkSZLUxgwYMICtt96a6dOnN7vs4MGD+ec//8nLL79cGrI8\ndepUdtxxRyALwVdddRVXXXUV06ZNY//992f33Xdn//33r1fPxhtvzLbbbsvf//731fYsrlixgrff\nfptFixZRVVXF1KlTuf7660th8Jvf/CZ77713afuRI0cycuRIIOspvvHGG9l9991Xeyx1PaLvvPMO\nb7zxBqeddhobbLABvXr14vjjj+fCCy9sNKT37duXn/70pwD8z//8DwcccAD77rsvM2fO5Ic//CGP\nPfYYO+ywAwC9evVa47XATXn99dfrPd9ggw3o3bs37733Xmn5lltuyYYbbsi8efPo0GHVfsbVtXeb\nbbZZ63Z9nNmTK0mSJLUxw4YNo3v37lx55ZW8//77fPDBBzz//PNMmTKltM3SpUtL15IuW7aMZcuW\nAVk4/cpXvsJFF13EkiVL+OMf/8j999/PMcccA2S35Xn55ZdJKdGjRw86duy42tvwHHLIITzxxBOl\n1/fccw/Tp09n5cqVzJkzh+985zt86lOfKvX67r777vzsZz9j6dKlvP/++/z0pz9l5513LpX/61//\nygcffMCcOXMYM2YMhx9+OIMHDwbgoYceYvbs2QC89NJLXHbZZaWZo3v37s3WW2/N9ddfzwcffMCC\nBQuYMGFCvbrL3XXXXfzjH/8Ash7piKBDhw4sXryYTp060bt3b5YvX86//du/rdLr3RwpJW677TZe\nfPFFlixZwkUXXcQRRxyxyjXO/fr146CDDuI73/kOixcvZuXKlbzyyiulSbdW116tHc+cJEmS1MZ0\n6NCBBx54gGeffZZtttmGTTfdlDFjxpQCWW1tLV27dmXHHXckIujSpUvpfrMA1113He+//z59+vTh\n6KOP5ic/+Ulp/YwZMzjwwAPp3r07e+65J6eeemq9GZTLjRkzhttvv730eubMmQwfPrw083CnTp24\n5557Sutvuukmamtr2WKLLdhiiy2ora1lwoQJpfVnnnkm1dXVbLfddmyyySb87Gc/K6177LHH2Hnn\nnenWrRuHHnooI0eO5Lzzziut/81vfsNDDz3Epptuyic+8Qk23HBDrrnmmkbbPWXKFPbYYw+6d+/O\n4YcfzrXXXsvAgQMZPnw4w4cPZ/DgwQwcOJAuXbowYMCAUrmIWCWgrul1RHDMMcdw/PHH069fP5Yv\nX861117b6La/+MUvWL58OUOHDqVXr14cccQRvPXWW2tsr9ZOrEvXfJOVR6Tm1n/88WMZOHBsi7aj\ntnYst9zSsnVKkiSpfWs42y/AmeecyYKlC9bbPqs2qmL85ePXW/3rw9e//nWOPPLI1U7y9HG23377\nccwxx/Av//Ivrd2U9a6x90vZ8lWn525FXpMrSZIk5dpbAP0olPfkalXrs9NQa8fhypIkSZK0lhq7\nx7Balz25kiRJkrQWHn/88dZughrxsQi5T/31KY4/8/gWrbM9Xk8hSZIkSUX3sQi5yz9YzsARA1u0\nztp7a1u0PkmSJEnSuvOaXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJElSq3v44Yf58pe/3NrN\naJdqamq48cYb16mOs846i5/85Cct1KLW9bGYeEqSJEmqxJlnjmXBgvVXf1UVjB8/dv3tYD0YM2YM\nTz75JDNmzOCmm27iuOOOq7f+mmuu4corr2TJkiV89atf5frrr6dz587N3s/555/Pddddt8ryJ554\ngv3224/zzz+fSy+9FIC33nqLMWPG8Ne//pVZs2ZRW1vLgAEDSmXOOuss7rvvPt566y0233xzzjvv\nPI455piKjun555/nu9/9Ln/729+YN28eK1eubPaxfNQiYp3v13vWWWcxbNgwTjzxRDbYYIMWalnr\nMORKkiRJuQULYODAseut/tra9Vf3+rLLLrswatQozj777FWC1MMPP8wVV1zB448/Tr9+/fjyl7/M\nxRdfzLhx45q1j6effppFixYxbNiwestXrFjBGWecwR577FFv3x06dOCQQw7hvPPOY88991ylvm7d\nuvHAAw8wePBgnnrqKYYPH86gQYP47Gc/2+Qxde7cmVGjRnHqqacyYsSIZh1He7bZZpux3Xbbcd99\n9zFy5MjWbs46cbiyJEmS1AYNHDiQq6++mp133pmqqipGjRrFsmXLSut/9rOf8YlPfIJNNtmEww8/\nnFmzZpXWdejQgRtuuIHBgwdTXV3Naaedttr9pJS4/PLLGTRoEL179+aoo45i/vz5pfWnnHIK+++/\nPxtttNEqZSdMmMA3vvENtt9+e6qqqrjooou45ZZbSuuvuOIKtthiC3r06MF2223HY4891mgbHnro\nIWpqalZZfvXVVzN8+HCGDBlCSqm0vE+fPpx00knstttujdY3duxYBg8eDMCwYcPYe++9+dOf/lTR\nMQ0ePJgTTjiBoUOHNlp3Q9/+9rfp27cvPXv2ZKeddmLatGkAPPjgg+y666707NmTAQMGcMkll5TK\n1NbW0qFefc5EAAAgAElEQVRDB2655RYGDBhAr169uOGGG3j66afZaaedqK6u5vTTTy9tf8stt7DX\nXntx+umnU1VVxfbbb7/acwlw0003MXToUHr16sXw4cN5/fXXm2wvZMOeH3zwwYqOuy0z5EqSJElt\nUERw11138fDDD/Pqq6/y3HPPlQLkY489xnnnncddd93FrFmz2GqrrRg1alS98g8++CBTpkzhueee\nY+LEiTz88MON7ufaa6/lvvvu48knn2TWrFlUV1dz6qmnVtTGF154gZ133rn0eqeddmL27NnMnz+f\nv//97/zXf/0XU6ZMYdGiRTzyyCMMHDiw0Xqef/55hgwZUm/Za6+9xs0338yFF15YL+A21/vvv8/T\nTz/NjjvuuNZ1rM7DDz/MH/7wB2bMmMHChQu566672GSTTYCsN/m2225j4cKFPPjgg1x//fX89re/\nrVf+qaee4uWXX+ZXv/oVZ5xxBuPGjeOxxx5j2rRpTJw4kSeffLLetoMGDWLevHlccsklfOUrX2FB\nI2Prf/vb3zJu3Djuuece5s6dy957783o0aObbC/Adtttx9SpU1v8PH3UDLmSJElSG/Wtb32LzTbb\njOrqar70pS/x7LPPAnD77bdz4oknsssuu9C5c2fGjRvHn/70p3o9dueccw49evRgyy23ZL/99iuV\nbeiGG27gsssuo3///mywwQZcfPHF/PrXv67oWtR3332Xnj17ll736NEDgMWLF9OxY0eWLVvGtGnT\nWLFiBQMGDGCbbbZptJ4FCxbQvXv3VY79sssuY+ONN16na05POukkdtllFw466KC1Kr8mnTt3ZvHi\nxbz44ousXLmSIUOGsNlmmwGw7777ssMOOwDwyU9+klGjRvHEE0/UK3/hhRfSuXNnDjzwQLp168bo\n0aPp3bs3/fv3Z++99+aZZ54pbdunTx/OOOMMOnbsyJFHHsmQIUN44IEHVmnTT37yE84991yGDBlC\nhw4dOPfcc3n22Wd5/fXX19hegO7duzcanNsbQ64kSZLURpUHkC5duvDee+8BlHpv62y88cZssskm\nzJw5s9GyXbt25d133210H7W1tXz5y1+murqa6upqhg4dSqdOnZg9e3aT7evWrRuLFi0qvV64cCGQ\nhaVBgwYxfvx4xo4dS9++fRk9enS9IdXlqqur69Vz//338+6773LEEUcA2ZDqtenN/d73vscLL7zA\nxIkTm122Evvttx+nnXYap556Kn379uWb3/wmixcvBuAvf/kL++23H3369KGqqoobbriBefPm1Svf\nt2/f0vMuXbqs8rru7w2w+eab1yu71VZbNXo+X3vtNc4444zS37Oup/bNN99cY3sh+3GiqqpqHc5I\n22DIlSRJktqZ/v37U1tbW3r93nvvMW/evFWCUCUGDBjA73//e+bPn196LFmyhH79+jVZdocddqjX\nQzx16lT69u1LdXU1AKNHj+YPf/gDr732GhHB2Wef3Wg9O+20E9OnTy+9fuyxx5gyZQr9+vWjX79+\nTJw4kfHjxzfrFkMXX3wxDz/8MI888gjdunWruFxznX766UyZMoUXXniB6dOn88Mf/hCAr33ta4wY\nMYJ//OMfLFiwgJNOOmmdZmou/wEDsjDbv3//VbYbMGAAP/3pT+v9Pd977z322GOPNbYX4MUXX2SX\nXXZZ6za2FYZcSZIkqZ2o680cPXo0N998M1OnTmXZsmWcd9557LHHHvVuo9NYucacdNJJnHfeeaWh\nznPmzOG+++4rrV+xYgVLly5l5cqVLF++nKVLl5bqO/bYY7nxxht58cUXmT9/PpdeeiknnHACANOn\nT+exxx5j2bJlbLjhhmy00UZ07Nix0TYccsgh9YbyXnrppcyYMYOpU6fy7LPPcthhhzFmzBhuvvnm\n0jZLly5l6dKlqzwHGDduHHfccQeTJk0qBe5yazqmuvqWL18OwLJly+pN+FVuypQp/OUvf2HFihV0\n7dq13jG+++67VFdX07lzZ5566il++ctfNnvIdXmb3n77ba699lpWrFjBXXfdxUsvvcQhhxyySpmT\nTjqJH/zgB7zwwgsApWtvm2ovZLdr+sIXvtCsNrZFhlxJkiSpHSi/LvXzn/88l156KSNHjqR///68\n+uqr3HnnnfW2XV3Zhs444wwOO+wwDjroIHr06MFnP/tZnnrqqdL6Aw88kK5du/LnP/+ZMWPG0LVr\nV/7whz8AcPDBB/P973+f/fbbj4EDB7LtttuWZhFetmwZ5557Lptuuin9+vVj7ty5q721UN0sxHX7\n7datG3369KFPnz707duXLl26sPHGG9cbStu1a1d69OhBRLDddtux8cYbl9adf/75vPHGGwwaNIju\n3bvTvXt3Lr/88oqOqba2lq5du7LjjjsSEXTp0oXtt9++0XYvWrSIMWPG0KtXLwYOHEjv3r353ve+\nB8B1113HRRddRI8ePbj00ks56qijVvmbNKV8m8985jPMmDGDTTfdlAsvvJC777670QA/YsQIzj77\nbEaNGkXPnj355Cc/WZp0bE3tnTVrFi+++GIhbpsU6zJTWZOVR6Tm1n/88WNb/N5kt008gKOv+1yL\n1ll7by23jL+lReuUJEnSRyciVunhPPPMsazPeXeqqmD8+LHrbwft2KRJk7juuuu45557Wrspbc4t\nt9zCjTfeWAri68NZZ53FoEGDOOmkkxpd39j7pWz52s0Ktp50au0GSJIkSW2FAbT1HHjggRx44IGt\n3YyPrauuuqq1m9BiHK4sSZIkSW3YutxC6ePIkCtJkiRJbdhxxx3Hk08+2drNaDcMuZIkSZKkwjDk\nSpIkSZIKw5ArSZIkSSoMQ64kSZIkqTC8hZAkSZI+tpyxViqeikJuRFQBPwd2ABJwAjAD+BWwFVAL\nHJlSWo+3zpYkSZJaTkqptZsgFVJr58dKhyv/CPhdSml7YCfgJeAcYFJKaTDwaP5akiRJkvTx1qr5\nscmQGxE9gb1TSjcBpJT+mVJaCBwGTMg3mwCMWF+NlCRJkiS1fW0hP1bSk7s1MCcibo6Iv0XEzyJi\nY6BvSml2vs1soO/6aqQkSZIkqV1o9fxYyTW5nYBPAaellJ6OiPE06FpOKaWIaPSihrFjx5ae19TU\nUFNTs9aNlSRJkiS1nsmTJzN58uQ1bbJO+bElVBJy/wH8I6X0dP7618C5wFsRsVlK6a2I6Ae83Vjh\n8pArSZIkSWq/GnZcXnLJJQ03Waf82BKaHK6cUnoLeCMiBueLDgCmAfcDx+XLjgPuXS8tlCRJkiS1\nC20hP1Z6n9zTgdsjojPwCtkU0B2BiRFxIvkU0OulhZIkSZKk9qRV82NFITelNBXYvZFVB7RscyRJ\nkiRJ7Vlr58dK75MrSZIkSVKbZ8iVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmS\nJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmS\nJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmS\nJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeS\nJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciV\nJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhy\nJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBid\nKtkoImqBRcAHwIqU0rCI6AX8CtgKqAWOTCktWE/tlCRJkiS1A62dHyvtyU1ATUpp15TSsHzZOcCk\nlNJg4NH8tSRJkiTp461V82NzhitHg9eHARPy5xOAES3SIkmSJElSe9dq+bE5Pbn/HRFTIuJf82V9\nU0qz8+ezgb4t3jpJkiRJUnvTqvmxomtygb1SSrMiYlNgUkS8VL4ypZQiIrV88yRJkiRJ7Uyr5seK\nQm5KaVb+75yIuAcYBsyOiM1SSm9FRD/g7cbKjh07tvS8pqaGmpqadW2zJEmSJKkVTJ48mcmTJ69x\nm3XJjy2hyZAbEV2BjimlxRGxMXAQcAlwH3AccEX+772NlS8PuZIkSZKk9qthx+Ull1xSb/265seW\nUElPbl/gnoio2/72lNIjETEFmBgRJ5JPAb2+GilJkiRJahdaPT82GXJTSq8CuzSy/B3ggPXRKEmS\nJElS+9MW8mNzbiEkSZIkSVKbZsiVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmS\nJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmS\nJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmS\nJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeS\nJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciV\nJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhy\nJUmSJEmFYciVJEmSJBWGIVeSJEmSVBiGXEmSJElSYRhyJUmSJEmFYciVJEmSJBWGIVeSJEmSVBgV\nhdyI6BgRz0TE/fnrXhExKSKmR8QjEVG1fpspSZIkSWovWjNDVtqTewbwApDy1+cAk1JKg4FH89eS\nJEmSJEErZsgmQ25EbAEcAvwciHzxYcCE/PkEYMR6aZ0kSZIkqV1p7QxZSU/uNcD3gJVly/qmlGbn\nz2cDfVu6YZIkSZKkdqlFMmRE9ImIyyLiPyLiE5XufI0hNyK+CLydUnqGDxN4PSmlxIdd0JIkSZKk\nj6kWzpBXA48A9wC/rLQNnZpYvydwWEQcAmwE9IiIW4HZEbFZSumtiOgHvL26CsaOHVt6XlNTQ01N\nTaVtkyRJkiS1IZMnT2by5Mlr2mStM2REPAz8e0rpyXxRZ+BVskC8YaVtjCxEV7BhxL7AWSmlL0XE\nlcC8lNIVEXEOUJVSWuXC4YhIldZf5/jjxzJw4NhmlWnKbRMP4OjrPteiddbeW8st429p0TolSZIk\nqT2JCFJKjfbYNjdD5jMuXwBsAZxPNvL4YqAr8B8ppT9W0qamenIbqkuslwMTI+JEoBY4spn1SJIk\nSZKKr+IMmVJaAJwVEdsClwFvAqenlOY3Z4cVh9yU0hPAE/nzd4ADmrMjSZIkSdLHR3MzZEQMAk4C\nlgNnAdsCd0bEg8B/pZQ+qGS/ld4nV5IkSZKk9ekOskmmJgO/yK/NHQ4sBCZVWklzhytLkiRJkrQ+\n1E00tTHZdbh1MzFPiIi7Kq3EkCtJkiRJagtOAf4TWEE2bLkkpbSk0koMuZIkSZKkVpdS+h/gf9a1\nHq/JlSRJkiQVhiFXkiRJklQYhlxJkiRJUpsREZ9cl/KGXEmSJElSW3J9RDwdEadERM/mFjbkSpIk\nSZLajJTS54CvAwOAv0XEHRFxUKXlDbmSJEmSpDYlpTQduAA4G9gX+FFE/D0iRjZV1pArSZIkSWoz\nImLniLgGeBHYH/hiSml7YD/gmqbKe59cSZIkSVJbci1wI3B+SmlJ3cKU0psRcUFThQ25kiRJkqS2\n5FDg/ZTSBwAR0RHYKKX0XkrpF00VdriyJEmSJKkt+W+gS9nrrsCkSgsbciVJkiRJbclGKaV3616k\nlBaTBd2KGHIlSZIkSW3JexHx6boXEbEb8H6lhb0mV5IkSZLUlpwJTIyIWfnrfsBRlRY25EqSJEmS\n2oyU0tMRsT0wBEjA31NKKyotb8iVJEmSJLU1uwFbk2XWT0UElcysDIZcSZIkSVIbEhG3AdsAzwIf\nlK0y5EqSJEmS2p1PA0NTSmltCju7siRJkiSpLXmebLKptWJPriRJkiSpLdkUeCEingKW5ctSSumw\nSgobciVJkiRJbcnY/N8ERNnzihhyJUmSJEltRkppckQMBAallP47IrrSjOzqNbmSJEmSpDYjIsYA\ndwE35Iu2AO6ptLwhV5IkSZLUlpwKfA5YBJBSmg70qbSwIVeSJEmS1JYsSynVTThFRHSiGdfkGnIl\nSZIkSW3JExFxPtA1Ig4kG7p8f6WFDbmSJEmSpLbkHGAO8H/AN4HfARdUWtjZlSVJkiRJbUZK6QPg\np/mj2Qy5kiRJkqQ2IyJebWRxSiltU0l5Q64kSZIkqS3Zvez5RsBXgU0qLew1uZIkSZKkNiOlNLfs\n8Y+U0njg0ErL25MrSZIkSWozIuLTfHjLoA7AbkDHSssbciVJkiRJbcnVfBhy/wnUAkdWWtiQK0mS\nJElqM1JKNetS3pArSZIkSWozIuK7fNiTW1qc/5tSSv+xpvKGXEmSJElSW/JpshmW7yMLt18Engam\nV1LYkCtJkiRJaku2BD6VUloMEBEXA79LKX29ksLeQkiSJEmS1Jb0AVaUvV6RL6uIPbmSJEmSpLbk\nF8BTEfEbsuHKI4AJlRY25EqSJEmS2oyU0r9HxO+Bz+WLjk8pPVNpeYcrS5IkSZLamq7A4pTSj4B/\nRMTWlRY05EqSJEmS2oyIGAt8HzgnX9QZuK3S8oZcSZIkSVJb8mXgcOA9gJTSTKB7pYUNuZIkSZKk\ntmRZSmll3YuI2Lg5hdcYciNio4j4S0Q8GxHP593GRESviJgUEdMj4pGIqFqrpkuSJEmSCqOFMuRd\nEXEDUBURY4BHgZ9X2oY1htyU0lJgv5TSLsAuwPCI+AzZ2OhJKaXB+Q7PWUM1kiRJkqSPgXXNkBER\nwK+Au/PHYODClNK1lbahyVsIpZSW5E87AxsACTgM2DdfPgGYvLpGSpIkSZI+PlogQ/4upbQj8Mja\n7L/Ja3IjokNEPAvMBh5JKT0F9E0pzc43mQ30XZudS5IkSZKKZV0yZEopAX+NiGFru/9KenJXArtE\nRE/gnojYsWEjIiKtbQMkSZIkScXRAhlyD+DoiHiNfIblvNhOley/yZBb1pCFEfE4cDAwOyI2Sym9\nFRH9gLdXV27s2LGl5zU1NdTU1FS6S0mSJElSGzJ58mQmT55c0bbNzZARMSCl9Hq+fQJibdq4xpAb\nEb2Bf6aUFkREF+BA4HLgPuA44Ir833tXV0d5yJUkSZIktV8NOy4vueSSeuvXMUP+Ftg1pVQbEXen\nlEauTRub6sntB0yIiI5k1+/+KqX0u4j4MzAxIk4EaoEj12bnkiRJkqRCaakMuc3aNmCNITel9H/A\npxpZ/g5wwNruVJIkSZJUPG0hQ1Z8Ta4kSZIkSevRThGxOH/epew5ZBNP9aikEkOuJEmSJKnVpZQ6\ntkQ9Td4nV5IkSZKk9sKQK0mSJEkqDEOuJEmSJKkwDLmSJEmSpMIw5EqSJEmSCsOQK0mSJEkqDEOu\nJEmSJKkwDLmSJEmSpMIw5EqSJEmSCsOQK0mSJEkqDEOuJEmSJKkwDLmSJEmSpMIw5EqSJEmSCsOQ\nK0mSJEkqDEOuJEmSJKkwDLmSJEmSpMIw5EqSJEmSCsOQK0mSJEkqDEOuJEmSJKkwDLmSJEmSpMIw\n5EqSJEmSCsOQK0mSJEkqDEOuJEmSJKkwDLmSJEmSpMIw5EqSJEmSCsOQK0mSJEkqDEOuJEmSJKkw\nDLmSJEmSpMIw5EqSJEmSCsOQK0mSJEkqDEOuJEmSJKkwDLmSJEmSpMIw5EqSJEmSCsOQK0mSJEkq\nDEOuJEmSJKkwDLmSJEmSpMIw5EqSJEmSCqNTazdAa+fMc85kwdIFLVpn1UZVjL98fIvWKUmSJEkf\nJUNuO7Vg6QIGjhjYonXW3lvbovVJkiRJ0kfN4cqSJEmSpMIw5EqSJEmSCsPhyh+BM88cy4KWvXyW\np6ZOb/HhypIkSZLU3hlyPwILFsDAgWNbtM4/PvXHFq1PkiRJkorA4cqSJEmSpMIw5EqSJEmSCqPJ\nkBsRW0bE4xExLSKej4hv5ct7RcSkiJgeEY9ERNX6b64kSZIkqa1qC/mxkp7cFcC3U0o7AHsAp0bE\n9sA5wKSU0mDg0fy1JEmSJOnjq9XzY5MhN6X0Vkrp2fz5u8CLwObAYcCEfLMJwIj11UhJkiRJUtvX\nFvJjs67JjYiBwK7AX4C+KaXZ+arZQN8WbZkkSZIkqd1qrfxYcciNiG7A3cAZKaXF5etSSglILdw2\nSZIkSVI71Jr5saL75EbEBmQNvDWldG++eHZEbJZSeisi+gFvN1Z27Nixpec1NTXU1NSsU4MlSZIk\nSa1j8uTJTJ48eY3brEt+bAlNhtyICOBG4IWU0viyVfcBxwFX5P/e20jxeiFXkiRJktR+Ney4vOSS\nS+qtX9f82BIq6cndCzgaeC4insmXnQtcDkyMiBOBWuDI9dJCSZIkSVJ70er5scmQm1L6I6u/dveA\nlm2OJEmSJKm9agv5sVmzK0uSJEmS1JYZciVJkiRJhWHIlSRJkiQVhiFXkiRJklQYhlxJkiRJUmEY\nciVJkiRJhWHIlSRJkiQVhiFXkiRJklQYhlxJkiRJUmEYciVJkiRJhWHIlSRJkiQVhiFXkiRJklQY\nhlxJkiRJUmEYciVJkiRJhWHIlSRJkiQVhiFXkiRJklQYhlxJkiRJUmEYciVJkiRJhWHIlSRJkiQV\nhiFXkiRJklQYhlxJkiRJUmEYciVJkiRJhWHIlSRJkiQVhiFXkiRJklQYhlxJkiRJUmEYciVJkiRJ\nhWHIlSRJkiQVhiFXkiRJklQYhlxJkiRJUmEYciVJkiRJhWHIlSRJkiQVhiFXkiRJklQYhlxJkiRJ\nUmEYciVJkiRJhWHIlSRJkiQVhiFXkiRJklQYhlxJkiRJUmEYciVJkiRJhfH/27vzcDuqKv3j35cA\nMgqKgghqaAQFG0RApNGWQVFsacQBJ4QILY0DItgONPBrg6gERUCl0VaZRMFGRURBBJWgOBAH5kFs\nJUzKoBJlFJK8vz92HTi5uQnknJPU3ZX38zw+qVPFPa567jl1a9Xee60kuREREREREdEZSXIjIiIi\nIiKiM5LkRkRERERERGckyY2IiIiIiIjOSJIbERERERERnZEkNyIiIiIiIjojSW5ERERERER0RpLc\niIiIiIiI6IwkuREREREREdEZSXIjIiIiIiKiMx41yZV0oqTbJV3Zt++Jki6QdL2k8yWtvnjDjIiI\niIiIiIluIuSPj2Uk9yRgpzH7DgIusL0h8IPmdURERERERCzdWs8fHzXJtf1j4K4xu3cBTmm2TwF2\nHXFcERERERERUZmJkD8OuiZ3Ldu3N9u3A2uNKJ6IiIiIiIjoliWaPy477BvYtiQv6PjUqVMf3t5u\nu+3Ybrvthv2/jIiIiIiIiBZMnz6d6dOnD/zzj5Y/jsKgSe7tkp5i+zZJawN3LOg/7E9yIyIiIiIi\nol5jBy4PO+ywx/Jjjzl/HIVBpyufDUxptqcAZ40mnIiIiIiIiOiYJZo/PpYWQqcDPwWeJelmSXsB\n04AdJV0P7NC8joiIiIiIiKXYRMgfH3W6su03LeDQS0ccS0RERERERFRsIuSPg05XjoiIiIiIiJhw\nkuRGREREREREZyTJjYiIiIiIiM5IkhsRERERERGdkSQ3IiIiIiIiOuNRqytHLCkHHHQAsx6YNdL3\nXH2F1Tl22rEjfc+IiIiIiJi4kuTGhDHrgVlM3nXySN9z5lkzR/p+ERERERExsWW6ckRERERERHRG\nktyIiIiIiIjojCS5ERERERER0RlJciMiIiIiIqIzkuRGREREREREZyTJjYiIiIiIiM5IC6EYyAEH\nTGXWaFvaMuPy60feQigiIiIiIpYuSXJjILNmweTJU0f6nhfPuHik7xcREREREUufTFeOiIiIiIiI\nzkiSGxEREREREZ2RJDciIiIiIiI6I0luREREREREdEaS3IiIiIiIiOiMJLkRERERERHRGUlyIyIi\nIiIiojOS5EZERERERERnJMmNiIiIiIiIzkiSGxEREREREZ2RJDciIiIiIiI6I0luREREREREdEaS\n3IiIiIiIiOiMJLkRERERERHRGUlyIyIiIiIiojOS5EZERERERERnJMmNiIiIiIiIzkiSGxERERER\nEZ2RJDciIiIiIiI6I0luREREREREdMaybQcQ0WUHHHQAsx6YNdL3XH2F1Tl22rEjfc+IiIiIiK5I\nkhuxGM16YBaTd5080vecedbMkb5fRERERESXZLpyREREREREdEaS3IiIiIiIiOiMJLkRERERERHR\nGVmTGwEccMBUZo22PhQAMy6/fuRrciMiIiIiYsGS5EYAs2bB5MlTR/6+F8+4eOTvGRERERERC5bp\nyhEREREREdEZSXIjIiIiIiKiM5LkRkRERERERGckyY2IiIiIiIjOSOGpiHjMDjjoAGY9MPoy1Kuv\nsDrHTjt25O8bEREREUufoZJcSTsBxwKTgC/aPnIkUUXEhDTrgVmLpSXSzLNmjvw9IyIiIqIdbeeJ\nAye5kiYBxwEvBW4FfiHpbNvXjiq4Ubn/3vvbDmHkck51aPOcFkfv3wsvvpS9Otb3d/r06Wy33XZt\nhzFSOac65Jwmvq6dD+ScapFzqkPXzmlU5zMR8sRhRnK3Av7P9kwASV8FXgVMvCT3vg4mTzmnKrR5\nTouj9+/d55w90vebCA469CCeveWzR/qebU+/7tofXcg51aJr59S184GcUy1yTnXo2jmN8HxazxOH\nSXLXAW7ue30L8ILhwomIWLDFMTr9u//7Mzt9ZPJI3zPTryMiImIp1nqeOEyS65FFERHxGCyO0ek5\nc8XMpNIAAB80SURBVLo3Oh0RERHRotbzRNmDxSBpa2Cq7Z2a1/8JzO1fVCyp9ROMiIiIiIiIxce2\netuPJU9c3IZJcpcFfgO8BPgDMAN400QsPBURERERERGL30TIEweermx7tqT9gO9RSkOfkAQ3IiIi\nIiJi6TUR8sSBR3IjIiIiIiIiJppl2g4gHhtJy42z70ltxBIRsSR17VonaTVJW0h6QtuxRLdJ2lbS\ns5rtF0l6v6RXth1XRMTi1qkkV9LjJC3T93oHSe+T9Io24xqGpO0l3QLcJul8Sev1Hb6grbhiXpLW\nkPQhSW+TtIykQySdI+kTNd7ISnqNpDWa7TUlfUnSVZL+V9K6bcc3KEk7Sfo3SZPH7N+7nYhGT9Lm\nbccwDEmvkHSDpIslPU/S1cAlkm6V9NK24xuEpK/0EnVJLweuBI4ELpf0+laDG4Kkx0taf5z9m7YR\nz6hJ+ljbMQxD0qeAI4AvSzoc+DiwAnCgpKNaDS4eJmlZSW+X9BFJLxxz7NC24ho1Sde3HcMwJK0v\n6aTm97SqpC9IulrS18beU9RI0gaSXidp47ZjGZVOTVeWdAWwre27JL0feDVwLrAt8CvbB7Ua4AAk\n/RKYAlwDvBaYBuxh+2eSLrX9vFYDHBFJP7S9Q9txDErSd4ErgMcDG1FuYr8G7AhsavtVLYa3yCRd\na3ujZvsM4GfA1ykFBHa3vWOb8Q1C0hHAC4FfA/8KfMr2p5tjVX6X+hJaUcr1Czibcn7Y/nVLoQ1M\n0uXAG4HVgXOAf7H9c0kbAadV+nu6yvY/Nts/oxTfmNkkvj+0XV1S2CTnxwJ3AMsBe9me0Ryr7vsk\n6TPj7N4T+BJg2/sv4ZCGJuka4B+BFYFbgXVs39vMDLvM9nNaDXAAkt4NfNX2nZKeCZwIbEopcPM2\n21e2GuAAJJ1A+R39AngLcJHt9zbHqvsuAUi6m0f+JvWsBNxH+T49vpXAhiDpx8BplL9NbwFOAs6g\n3OftXts9rKTpwOts/0nSHsD/A35E6WX7hd79Uc2G6ZM7ES1j+65m+43Ai2zfL2kacClQXZILLG/7\n6mb765KuBc6U9ME2gxqGpCuZ/+K3YW9/jTd8wFNtv0KSgFttb9fs/1Fz016b/lke69vujTadLOnA\nNgIagX8Fnmf7IUlTgdMl/QNQ6/kA/BL4OfD3vn1PBD7ZbG+/xCMa3pxecQpJ99r+OYDta5vvV40k\naTXbfwXmADcDNDcXk9oNbWCHAFvY/qOkrYAvSTrY9pltBzagVwMXAec3r0W5j/hlaxENby7lb+2c\n5l/37a/1u/QO270HEp8GjgHOogxmfI7yILM2W9neBEDSccDxks4E3txuWEM5iZIMfsD2bc21+/e2\n13uUn5vIVrH9WQBJ77Tdmw1xQvPwpTZPsv2nZvs9wD/Z/rOklYBLKN+vqnVqujJwt6RNmu07KU/G\noDxlrvWC/qCkp/ReNAnvS4DDgA1ai2o4N1BGOl8P7ExJPu5otndpMa5hSNITgacBK/emlTcjNfOt\np67ARZI+LGlFYLqk10CZPg/Maje0gU2y/RCA7VmUz93jKSPuy7cZ2BB2A2YDn7C9ve3tgdv6tmv0\nV0n7SvoAcJekAyWtI2kKcE/bwQ3oMODCZlr8T4AzJL1V0snAea1GNrhJtv8I0Izgbg8cIuk97YY1\nsI2BPwE7ARfYPhm4x/Yptk9pNbLBnQv8GLgYOIHyuTuU8pn7UZuBDaH/odCTbX/TxXRg1ZZiGtbD\n9wi2H7K9D3A58ANgldaiGkIz8+HTwGnNNaEL+cZcSc9qHuqtKOn5UKb5Uuf5PdS3/Oxuyig7lIfm\nNZ7PfLo2XXlT4FTKtFEDL6JcyDcBjrb9lRbDG4ikHYE7bV82Zv/qwH62P9JOZMNpkqYDgaNsf0vS\nDTU/4ZP0JsrUPQHvBN7eHNoYOMz2/7QV2yAkLU8Zqdmr2bUu5QL4beCDtm9qK7ZBSToH+Ljti8bs\n/whwsO0qL+qSVgUOB9YB3gdMr/y79HTgUMpo01TKaMbewE3Af9Taqq65EdqH8nByOcpo7lm2v9dq\nYAOS9FPK0pnf9e17PPBN4J9tV/ngSNIWwFGUBHE/289oOaShSNqGMkPqZ8303lcDNwJftz233egW\nnaSPUq51H6aMtN8PnAnsALzW9s4thjcQSV8Bvmz7u2P2vw34rO0aH5QD0MxU2Q94HfBM22u3HNLA\nJL0E+Czlb9M+lHvYTYHVgH1sn9VieItM0nbAfwPfoMwA25wyk+VFwHl9I9XV6lSSCw83H34Z895I\nnN83jTkmCEmrUG7O/wHY0vY6LYc0lOazp2Y67HLAc4E/2P5Dy6ENpXmgsizwZ1d8wWhGpbF9/zjH\n1rV9y5KPanSa9blHA8+x/eS244luk7QZcK/t347Zvzzwettfbiey4akUsHwnsLXtt7QdzyhJerLt\nO9uOYxiS9qI8SF4feBxwC2XK8rRmSUBMMJKeCmxm+9y2YxklSU8G7rI9u+1YBtHc372ZeXOmb9m+\nrtXARqRzSe7SRNJ3bVdbObqnuVna2vbn2o5llJo1G8e3HccwJG1JmYI9B7i+9gtfsy5oS8rIdCfO\nqV9zfqva/lvbsQyqmeVxUbM2aE3KqNrmwNWUkdzqHkY0SdNulBGAXgG3VwHXAp+rcURtaSBpC9u/\najuOQal0ljieUnRqf8pMtxUoieFbbX+/xfBiAZpaEc8Drq7571OTQO1EGXmH8jDie81yoSpJWg14\nBeWcTPluVX1OXdapJFfSTrbPa7ZXpxRf2Yqy/vNA27e3Gd8gmqlT4/2SBJxj+ynjHKuCpOV6ayT7\n9vUvhK+GpP8YZ/fBwEcBbB+9ZCMajqRtKd+fWcAWwE8pRSQeokxRvLnF8AbS0XNagzIV7FZKldH/\nBLahVGP/WI0zWNTNyt6fBZ5MWfv9N0qi8S1KHYLbbFe3jlXSXZRpbqdTKkRXfTOh8SuVf4umToRT\nqXxCkLQLZXbeA23HMiqSzrK9a7P9KsrSp+mUIlpH2D6pxfAGImlP4EOUVpe9B5NPo1QiPqzGde5d\nPKcFkfR52//edhzD6lqS+3CpdZWS7H8EvkhZg7Jt7yJSE0lzWHCBiK1tr7iAYxNWU7zoVEphsF8B\n+9q+oTlWa7n8eyg3Edf0dlGq1R0LYPuwlkIbiKTLgB1d2jSsBxxje9dmjfj7bb+s5RAXWUfPqVOt\nqwAk/cb2s5rtX9neou/Y5baf2150g1HTQqhZxnA7sLbtvzdLHC51U1m1JpJ+A3yGMtVtMuVzd7qb\nati1kTSX+SuVb93so8ZCbpJ+bXvzZvtm20/rO3aZ7c3ai24wku6n1Ic4l/KA5Xu257Qb1XDG3Lv+\nDHiz7RtUd4ux6ylVo2eN2f8EYIbt6gqndu2cVIqljnsIuKL2JYTQvRZC/bakzP83cIykt7Ycz6Cu\noySB8zXRllTdyFPjE8DLeaT37wWS9rD9s3bDGsrGlPWQKwNTbd8naUptyW2fZfrWbd0EPAPA9gWS\nPtVeWEPp4jl1rXUVNJW9gSNoKnvbPlN1V/aeDaVyqqRf2P5783p2k1zV6D7bxwHHSXoGZcTw+OaG\n73TbB7cb3iLbjfJg8hO9dYNNQcTqkts+f5W0L6Uwzl0q7d/OAF5KvZXKr6MUmdqNUmjvZJV2O6d7\nTFHBSi3fe+jv0mKs1uvDgnRnZO0RtZ7TnyhF6MbTiboeXUtynyzpvZSnEKuNOVZrC6GpLLiUd3XN\n6Rud6/3rUm34dZJ2Bb4v6Zi2YxrSr5rZEBdSputdCCBpZeotLd/Fc1LzNHYVmtZVfSMAtVbk3I9S\n2fs3zesDJfUqe+/RWlTDuU3SKrbvsf3y3k5JazPvyGGVbN8IHAkcKenZwBtaDmmR2f6GpPOBw5vC\nRu9rO6YRmMIjlcpfRhl1/x7lId8+LcY1lGYZxueBzzffoddTPnvr9I9WV2RTSXc32ytIWtul//Tj\nqPdv00cpf3PPZ96pvS+jFBytUdfO6ffAS5rr9zwqHkSbR9emK09l3icqn7V9R3MRPNL2nu1ENjqS\n/plmnbHt8x/tv5+IJP0S2Nn2bX371qVM913fdpV94XpUqkZPpUxreXHL4QxEpULqPpQpsJcDJ9qe\no1KheC3bM9uMbxAdPadOta4aSx2p7L0gzQOWVSqtF3G07fe2HcfioFQqn7AWtqRJ0uQar+ML0lz/\nNrb907ZjGUTzAPblwFObXbdS1lP/pb2ohtOlc5K0H3Cxx7QobY7tb/vTLYQ1Up1KcgGaggrrAD+3\nfU/f/ld4TA+yGkiaYXurZnsf4F2UPoQvA75j+4g24xuEOtr7N6INmr911WaUqctVtq6StKntK9qO\nY3FS6W28AfD7seu7YmJQqYi9qitvSSOpV932B/0JoKS9bZ/YWmADkrS97QvbjiNCpdLyBsDvaizy\nuDSodRrEuCTtT+mVth9wdTN1tOdj7UQ1tP4ph/tSCuccRklyd28npOHYvmC8J0e2Z9Wa4EpaXdI0\nSddJukvSX5rtaU3yXpWunc+jaQo41WoupR0SlBHduUDNlUcvlfRbSYdL2rjtYEZB0vF92y+itEP6\nJHCVpFe2FtiQJO0k6XOSvt3873NNUlU923N7Ca6k/2o7nkFIOoJS5X8T4AfNPVLPu9uJajhLW4Ir\n6cq2YxiEpI0kfVfSOZLWl3SypFmSZjSDUdWR9BWVvrhIejml0OM04HJJr281uAFJeryk9cfZX12x\ns/F0bU3uvwNb2L5H0mTKes/Jto9tN6yhTGqmRwiY1CucY/teSTU3nz4I2BVYizLF/A4eaeZe48jG\nGcAPgO2A2227mSY/pTlWW+Xerp1Pf4uQ+Q5RehJWp3mQ9z/AXElvp9zQ3gM8W9I7bJ/daoCDuYKy\n9vbNwNnNetzTgK9WPBXxn/q2PwLsavvXKv0wv0ZZqlEVlWJtGwBfokzZg9J/en9J/2K71poR49kH\n+HDbQQzgX4HnNbM8pgKnN5+5A9sNa3D9I9DNMqdTKC3hrqH0/p2vSOdEJ+m14+zutbFaewmHMyqf\nBz5OqRdxIfBBYG/glcBxlJZwtXluX/HKqcCLbc9samD8kHJvVI0mMT8WuKOZBbaX7RnN4VOo9L6o\nX6emK0u62vZz+l6vQunjdw2wfaXl8mfyyDpjAy9sChKsCvy40nM6n5JAncL8CdQOrrOVy/W2N1zU\nYxNV184HOtuO6zJgJ2Alyjrj59u+TqXa7Znua79Ti7Fr7iS9gFK5dzfgJtvbtBbcgDRvi5Cx51dr\n27TfjtcyQ5KA39p+ZgthDUyPFP4Zz4q2qxsUUF/P6eb1spTk4/HARv33S7UY8136GqVn6QmUYoL7\n2a4ueZL0EOVB3thKygJeV2OdkjG/p//rvx5UfM27GtjG9l8lXUxpTTqnd6y275NKB4admpxiK8oD\ny4ObbgZV/o7Gqu6i/SjukLRZbypsM6K7M+UCWOXQu+3JCzg0h9L/t0aTbR/Zv8P2H4FpkvZuKaZh\n3SjpA8ApvSIykp5CSdxvajWywXTtfKCb7bjcK+Am6Sbb1zU7b2zWFFbP9iXAJZL+A6iykBtlZL03\n7XA9SU+wfZekSdRbBfsBSVv1Pfnv2Qq4v42AhnQXpVjgbWMPVHx9+L2kbd201rE9G9hb0keA17Qb\n2kg8y/ZuzfY3JX2o1WgGdyVwlO35piZLqi5pb0zq2z56zLFar3mHARdKOg74CXCGpG9TZryd12Zg\nA5rU3Htje4ZKm77vSKqxQvm4upbk7gk81L+jmaYzhfL0sjNs3wfc0HYcA+piAvUGyhTsiySt1ey7\nHTib0t6gNl07H+hmOy4kLWN7LrBX375lqfdG4qjxdjbnOH3JhjIyY9eg3dv8+wSgyvWewFuBzzaz\ninrtNNYF/tYcq82pwNOB+ZJc4PQlHMuo7MY4PTxtHyrpcy3EMwrrSvo0ZZTzSZKWs92776v1nvYA\nyvdmPLU+jDhe0qq277bdX5PgmcD3W4xrYLbPkHQpZfnCBpS/sS+g9Gj+XqvBDeZvkta3/Tsog01N\novtNoKpR6QXp1HTlqEOzxvggyvSisQnUtBpLscM8lb0vsX133/6dbNf4lG8ekk61XWufUlR6Dr6R\nUnn4+5J2B7ahLGf4gu0HWw1wAM0Uoytt3z9m/2TgRba/3EZcsfRolpqs07y8tTcyEBOTpHf2Jx21\nkfRWHlmvauDbtv/SfA7fbfvgNuOLqIWkzYB7bf92zP7lgdd34f4hSW5MKJL2sn1S23EsKpWqle8C\nrqUs1n+P7bOaY9WtbWim4PRuJHp2oBRXsO1dWglsCJJOo0yhWgmYRSmIcSbwUgDbU9qLbnQkrWH7\nz23HMSiVtgz/SRkVPNf2aX3Hjrf9ztaCG1D/g66m8N4nafqdAwe6wj65CyPp2b2p87UZMzLY2/ck\n239qK6ZBNVP8xzoY+CiA7bHTSKMFko4BvmH74rZjWZwk/dD2Dm3HMShJa1C6t9xKWQZ5MI88KP+Y\n00ZowkmSGxOKpJttV7ceQNJVlOJFvcre3wBOtX1spUnupZQL9xcpxTBEmbL3RoDeGq+aSLrS9ibN\nVN4/AE+1PbsplHOF7U1aDnGRSTqSspbrTklbUqo7zqVMo5pie3qb8Q1C0pnA9cAllGqcDwK7236g\nxu8SzFeE5QTgj5Tv1qspxUt2XdjP16bG63gzTe9UYEXgV5T1+zc0x2r93N1Dqdx9TW8X8B5KRVVc\n2hFWZUyicSLlgVjViYakO4EbgTWBr1Kmv17ablTDaWoQjH1QviHl2m7b1dXJUWk1eAWwGmUJyhWU\n6vg7ApvaflWL4S0ySXdR7lVPB37oDiaEta5fiIpp4X3f1lrIsYlMtu8BcCkpvy3wDZUqt1r4j05I\nW1Juhg4B3m/7UkkP1Jjc9lEzZXklyo3sasCfgRWo91r4StsfbLaPAt5g+xeSNqT84aquujKwvu3e\nOrRvSjqE0uOzqhuIhdgS2Ky5oTimmX5ZHUmfWcjhGntpfwJ4OSVZei1wgaQ9bP+s3bCGsjGl6M/K\nwFTb90maUmNy2+fLlORiS+AtlNkQR1ISjZOBGq8Tt9jesrluvxH4cvMw9jRKwltdWyRKzZi7KS3T\n7qPcB/0Y2Jk674mgPBh/RfNg/Fbb2zb7f9RUKq7NHcBlwOHAqSrVyk+3/fN2wxqdWm/som5rUtqe\njPfE9adLOJZR6VRl76Ys/tGSzqDciN9B/deLEyjTyZcFDqVURrwB2Br43zYDG8KkvumVK9j+BYDt\n65t1NTVavq+YFrY/KulW4CLKFPMaPVnSeyk3d6uNOVbrDd9bgfcBf2fe4kai9DiuzfK2r262vy7p\nWuBMSR9c2A9NZLZvAl6n0k/7+8202NqNTTS2a/bXmmg8rElmPwx8WNJzgTcB3wXWbzWwAdjeRdJr\nKEVfj7L9LUmzbd/YdmxDUFNTZhVgZUnr2b5BpU9ujYUe77N9HHBcMyDzRkrBsCdQkt3q17fXftMa\ndToHWGW86TiSah0p7GRlb9u3ALs1Cftf245nGLaPaZJ2bN8q6UuU9bifH6cNSi2OB86VdARwnqRP\nUdYZ70B5Qluj7wAvofS/BMD2yZJuAxY2ejiRfRFYtdk+CXgScGdTVb7W39Mvgats/2TsAUlTl3w4\nQ3tQ0lN6LYRsX63SvuUcKkwy+tk+S9L3KRXma22H1NO1RGNcti+n9D4/qO1YBuXSb/V84HCV9pC1\nPnjtOYLyoFzAvwFfKM9a2JjSXqhazcOHI4EjJT2b0mGjelmTGxFRsWYt4TsoLQ2WpbRzOQs4cWwB\nnVpIegEwt5l6/RzKzI9rbZ/bcmgDkbQ1Jf6/SlqJcuO6OXA1cITtWa0GOIAm0XjApZ1d9STtCNzZ\nm43Tt391YD/bH2knsugn6U2UNcUC3gm8vTm0MXCY7f9pK7ZBqWm103Yci1NTyXdr27W2rgIebs+n\nZhBjOeC5wB9s/6Hl0BaZpGNsH9h2HItTktyIiA6quFL5VEpSuxxwPqUP4YWUNXfn15hsSLqGUphk\ntqQvUPrkfp0yk2DTvjXIMYGkUvnE1KVEo6eZfr0l5Xc1B7i+1grlPR09p6cDf7M9qyky+nzKA8yr\nWg0sxpUkNyKig2qscAsPVyrfjDK17XZg3WYEdEVgRqVVsK+1vVGz/Wvbm/cdu9z2c9uLbjAqfUn/\ni1LN+7+Ad1MKNl1LaaFWVb/chVQqXx7YM5XKJy7V3/t3W0pbsVmUYoE/pRRvewjYw3Z1U8w7ek4H\nAftSvkefoNQk+AmlrseJtj/ZYniLTNLRwJldbl2VNbkREZV6lErlay6xQEZrtu3ZwGxJv7P9VwDb\n90ua23Jsg7pa0t62TwQul/T8virYD7Yd3IBOpqyfXgWYDnwFeCWluu3nqK/KbSqVV0AL6P0raQWo\ntvfvp4Admwcs6wHH2H5hM4X+BOBl7YY3kC6e056UafErAzOB9ZrzWxmYQUnqa7IH8GJJnWldNVaS\n3IiIenWxUvnfJa3UrPXsH/FcnTLlrUZvAz4l6VDgTuCnkm6hFAF6W6uRDW5N258BkPQO29Oa/Z+R\nVOM5pVJ5HQ5j/t6/y/BIYbcaLWP7zmb7JuAZALYvaIoJ1qiL5zS7edj6IKUt0l8AbN8rqcZpsV1s\nXTWPJLkREfXqYqXybW0/ANC7OW8sC0xpJ6ThNIWlpjRrJNejKRDWq+RbqWX6tk9dyLFapFJ5HbrY\n+/dXkk6g1B7YpfmXZoSwxu8SdPOcLpV0OuWz90PgFEnnUa4R1yz0JyewLrWuGitrciMiImKRSDoc\n+PjYqrCSNqBUjH5dO5ENrqlU/nZgQzpSqbyfpH8GtgKutH1+2/EMQ6X37weAYyifw/VaDmlgzUyB\nfYCNKG2DTrQ9p6lDsJbtmW3GN4iOntNywG6UtfpfpxRFfDNwI/Dftu9tMbxF1qV1+QuSJDciIiJG\npm/9cVUkbQSsA1zSn7xL2sn2ee1FNhhJM2xv1WzvA7wL+CZlPeR3bB/RZnzDkrQKpffvVrZf3HI4\nEVVZGlpX1TplICIiIiam6qaOStqfMmq7H3BVM1LYU2syuFzf9r6UQkCHUZLc3dsJaXRs32P7fbUn\nuJJWlzRN0nWS7pL0l2Z7WlOLoFMkfbftGAYhaW1Jn5X035LWkDRV0pWSzmiqzdem2tkPj1XW5EZE\nRMQieZTK3mstsUBG59+BLWzf0/S//LqkybaPbTesoUyS9ERKcaZJvUJATaGc2e2GNpgm6TsI2JXy\nOTNwB+UBxbRm/XttzgB+AGwH3G7bTdI0pTlWXSViSZsv6BBQ6xTZk+lWRflLJf2eRyorV7uueEEy\nXTkiIiIWiaTbWUhlb9tPXcIhDUXS1baf0/d6FeAblIIy29verLXgBiRpJiUJpPn3hbb/KGlV4MeV\nntP5lITwFOZPCHewXWNCeL3tDRf12EQmaQ7wowUc3tr2iksynlHoX8Mq6SbbT+87Vl2/c0mXUtoI\nvRl4PaVi9GnAV2tcMz2ejORGRETEoupaZe87JG1m+zIoU2El7Uzp6blpu6ENxvbkBRyaA7x6CYYy\nSpNtH9m/w/YfgWmS9m4ppmHdKOkDwCm2bweQ9BRK4n5Tq5EN7jpg3/Ha0Ei6uYV4RqFrFeWxfRVw\nMKXX9AsorYQubpL4bdqNbnhV/lIiIiKiPbb3tv3jBRx705KOZwT2BOZp6dRUVJ4CVL3mcyzb99m+\noe04BnSjpA9IenhKvKSnSPog9SaEbwCeBFzUrMm9izIddg3KCFuNprLgHGP/JRjHKJ3dzPDA9iG9\nnZKeCfymtahGxPYltg8Enk5JfKuX6coRERERMeE1a4wPovRe7SW6twNnU9bk/qWt2IbRtcre45H0\nJdt7th3HoCQ9jjLSeavt70vaHdiGsqThC7YfbDXARSRpd9tfaTuOxSlJbkRERERUTdJetk9qO45F\n1VT2fhdwLaUo03tsn9Ucq7KXqaRvU9aBq2/3DsAPAdvepZXAhiDpNGASsBIwi1KA6kzgpQC2p7QX\n3WhIWsP2n9uOY1SyJjciIiIiavdhoLokl/kre3+jA5W916WMcH4RmEtJdrcEjmozqCFtYnsTScsC\nfwCeanu2pC8DV7Qc2yKTNA34pO07JW1JqeQ9V9LywJ62p7ca4AgkyY2IiIiICa+DraugzKq8B8D2\nTEnbUhLdZzDvSGhNtgTeAxwCvN/2pZIesF1jUboeNVOWVwJWBFYD/gysQJ351M62D2q2jwLeYPsX\nkjYETge2aC+00ajxlxIRERERS581WUjrqiUcy6h0sbL3HOBoSWcAx0i6g/pzjhMoU8qXBQ4FzpB0\nA7A18L9tBjagSZKWawrsrWD7FwC2r29Gc6uXNbkRERERMeFJOhE4abzK3pJOr7Gyt6SnAQ/Zvm3M\nflF6G1/cTmSj0yTt29iuumqvpHUAbN8q6QmU9bg32p7RbmSLTtK7KQXcjqBUkH8CZY3xDsA/2N6j\nxfBGIkluRERERETEUkTS9sA7gA0oI9S3AGcBJzYjvFVLkhsRERERERHVViofK0luREREREREIOlm\n209rO45h1b4IPCIiIiIiIh6jR6lUvuYSC2QxSpIbERERERGx9OhipfJ5JMmNiIiIiIhYepwDrGL7\n0rEHJNXcz/hhWZMbERERERERnbFM2wFEREREREREjEqS3IiIiIiIiOiMJLkRERERERHRGUlyIyIi\nIiIiojOS5EZERERERERn/H9z/kqpyWxJLAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f1802a85a10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The probability that the distributions for payload/histograms/GECKO_THREAD_ACTIVITY_MS (normalized) are differing by chance is 0.00.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7kAAAHZCAYAAABDzPyzAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3XucVXW9//HXBxAFucwgF0FFVAJFE60k09TRRElLMVIh\nrx075DWtLO86Hj2RpkfydLxUXihN00zzEimpaHUqpRSPqIH9HC8ICMhNkUvy/f2x1mz3DMPMAIMz\nLF/Px2M/Zu+11ve7vmvNzH7s9/5+13dFSglJkiRJkoqgXWs3QJIkSZKklmLIlSRJkiQVhiFXkiRJ\nklQYhlxJkiRJUmEYciVJkiRJhWHIlSRJkiQVhiFXUmFExK0RcdkGqLcqIl5vZH1NRHxuDev2iYiX\nWrpNktqOiDg4Iu5t5rbVEfHzFt5/o+9R61l3n4h4ISI6boj6JWlDMORKKpKUPza4iOhX9qFyjftN\nKf0hpbRjM+pr8Q++rSkizouI/8yfd42I/4qIVyLinYh4NSLujohhZduvytctKXucXbZ+UF5mbkQs\njIipEfHNiGgXEQPy8u3ybSMi/jsiXoyIvvnr70TE9IhYmu//e019aI+IiWVtWRERy8teX7emYBER\nkyPipPx5Vd62JRGxOCJeiogT623f6LHn25yYb3dUveXl9S+JiNcj4pcR8am1+F1FRPy/iJi2hnXf\niIj/y9v4ekTcFRG7rM35iYgbImJCA/UPjYhlEVFZ+z8QEdvUOx/1z8+F9UNXRGwREW9FxEGNHGft\nufp1A21YFRGPly07PCKejYhF+d/coxExoJHT+J/AuMbOc5kP5T1qTdb0d7smKaU5wOPA2A3XKklq\nWYZcSUUTH9J+DgEmfkj7Wi8R0aEVdnsI8FBEbAo8BuwMHAp0BXYC7gQ+X6/MrimlrmWPqwAiYgfg\nr8CrwC4ppQrgSOCTQJfyCvKgeyOwL7BvSmkWcC3w78Bx+fafBz4H3NXYAaSUPl/bFuB24Iqytp3a\nWFHqBpmZeZluwDeBn0TEoOYce5kTgLeB4xvY38yydu4JvAT8ISIOaOz4yuwL9AK2ayAc/xD4BnAG\nUAkMAu4DDl3L83Mr8KWI6Fxv+XHAAymlBbULUkqvp5S6lNUNdc/P5cBM4OKyesYDD6aUHmniWOcC\ne0ZEj7JlJwDTyX9nETEQmAB8M6XUHdgO+B/g/YYqjIg9gG4ppaea2HepSDO3a0tuB77e2o2QpOYy\n5Er60EU2vPfciJgWEW9HxM15GCIiKiLiwbxX5u2IeCAitsrXHRkRU+rV9a2IuG8N+/n3iJgREfMj\n4jcR0bds3Q8j4rW8p2ZKRHy2bF2nyIY+v533bu3RQPWHAL8te717ZL2LCyPizrLjqdNrEhHnRMQb\n8UGv3gERMQI4Dzg676l6Jt+2X0Tcn7d/RkR8rV4bJ+RtfCEivltvPzX5sueAJRHRPj/nL+f7nhYR\nI8u2PzEi/hRZj+uCiPhnRHwmX/5aRMyJiOPLtj8kr2NxfjzfLltXG4b+TBZitgJGppReSJmlKaV7\nUkqXNvR7a8ClwB9TSmfnvUqklKanlI5NKS0u264DcAvwCaAqpTQ3Ij4GnAJ8JaX015TSqpTSC8Ao\nYERE7N/MNkALhJOU0kSysPrxZu80YluyIPrvwMER0aeR+memlC4Bfgpc0cxdnAD8huxLmxPK9vsx\n4FRgdEppckppZUrpvZTSL1JKDdW9xvOTUvoLWTAdVVZ/e2AM8LNmtrPc14BT817Yg4EDyL5AaMoK\nspA+uqwNR5GFuNr27wa8klJ6PG/7OymlX6eU1tT7+XlgcvmCxt5fyML0Zvn7xOKI+FtE7FpWdrX3\niHz5phExPiJm5o9rYg2jESLrmd6+7PWtEXFZ/iXDRKBffDC6YMvI1L4/zItsNEBlWZVPAdtHxDaN\nnVxJaisMuZJay1eAg4AdyALRhfnydsBNQP/88R7wo3zd/WS9TeXDf48j63WpI/9g+D2yHr++ZL2A\nd5Zt8hQwlKx36hfA3WUfGC8h673ZHjiY7IN/qWcuIjYB9gEm1S7K93NwXm5X4MQG2jQYOA34VN6r\ndxBQk1L6Xd7WO/Oeqt3zIncCr+Xt/zLwvbJQdkl+frYDhgPHsvowyNFkH8ArUkrvAy8Dn833fSlw\nW73ANAyYCvTIz8kvyXpLd8jr/1F80BN3EzA2r2tnst7aWgcDv08pJeBA4Hcppffqn48GrCkkfQ74\nVTPK/wL4GHBAWc/g54DXU0p1vhxJKb0B/IXs3H0oIhtafRjQk+x3UWd1I0WPB55OKd0LvAgc04zd\n3Qt8IiI6NdGmzmTB8zayoDc6Puj5b/DcrYefUbcn+kBgE+p+WdQsKaVXyXpybwGuB05JKS1qZvGf\nl7XjYOB54M2y9X8Hdsy/8KmKiC71K6hnF+Af9ZY19v4SwOFkIwlq19+XfxHV4HtEXu4Csv/Roflj\nGB+8bzYlASmltBQYAbxZO7ogpTSbrLf+MLIvU/oCC8h6r7PCKf2L7G92t2buT5JalSFXUmtIwI/y\nXqcFZNezjQFIKb2dUro3pbQspfQOWfjbL1+3nCx4HQsQETsD2wIP1qsbsiBwU0rp2ZTSCrKe0s9E\nRP+8rttTSgvynr3/AjYFBudljwT+M6W0MA9DP6RuCNkXmJpSerdsn9emlGbnx/MADX8YfD/fz84R\nsUlK6bWU0v/L10X5PvIek72Ac1JKK1JKU8l652o/nB8JfC+ltCilNLOBNta2aWZ+3kgp/Sr/QEtK\n6S5gBvDpsjKvpJQm5OH0LmBr4D/yHrxJZL1gA/NtV+TH0S1vwzNl9RzKB8FlC2B22XHtlvcUL4rV\nJ+T6e76u9jG8rI5ZDZzP+g4EflWvd7dn+f7rmZXXvT761WvzAuCzDW0DLAV+TTYMdmq9bdZ07JD9\nzn+RP/8FDQ9Zru9Nsr+Hiia2+xKwDHgEeIgsdH4hX1fnd9cCbgP2i4h++evjgdvzL2DWWkrpR2R/\nh8+klO5fi3J/BnpENmT8eOp9SZb/T1aRjUC4C5gbEbdExOZrqLICWFKvjsbeXwCm5L3D7wP/BWxG\nNtS8sfeIr5D9P85LKc0j+6LquOYeNx+8PzT0hcrXgQtTSm+mlFbmdX858uvcc0uA7muxP0lqNYZc\nSa2lfOjfa0A/yHqWIuLGfLjtIuAJoHtE1H4wm0D2YQ+yD3i/zD+U1VfbewtAHkjnk31wJSLOjmyY\n78I8gHQnC0TkbanfvnKHkAWCcuVh4D3qXSuat+Fl4CygGpgTEXdE2RDqevoBb5cF6dp29CtbX97G\nNxqoo87wyog4PiKeKQtju1A35M2pdwyklOau4bhGkZ2HmsgmWtoz30c78t7bfLv5ZW0m/9Khkixc\nbVqvvbunlCrLHpMaqqMRXwAuiYivli2bR/a30JB++fr18Wa9NlcCf2xoG6Ab2fXBDc3E3eCxR8Te\nwACyL3cA7gA+HhFDm2jXVmRfdCxsYrsTgLvzMLacLITXDlmez5rP3VpLKb0GPAkcl/eOHs66DVUu\n9yKw2oRZzfBzsuuMq8h6vesEv3xo+9Eppd5kozb2JetJbcgCst9tSRPvL1D2/5p/qfQG0K+J94h+\nlL2nUff9YH0NAO4te294AfgXUD7SoytN/z1JUptgyJXUWvrXez4zf/5tsuHLw1I26ct+lPVyppT+\nCqyIiH3Jen/XNCPxm2Qf3ADIe2G2AGZGxD7Ad4AjU0oVeQBZxAcfdGc10L5yn2cdhljm7b8jpbQP\nWQ904oPrJusPNX6TrLepPCyXn6dZQPn1cQ1dK1c+xHpb4MdkQyF75Mf8POt4nWlKaUpKaSTZhEX3\n8cEkTnsAr6aU5uevHwUOitUnHFqb/f6esms5G/G/wBeBH0bEmLL9bxPZ5EAf7DzrKf90vv5DkY8o\nOIcspB7ezGInkJ2rZyNiFtkQ69rljTkC+Ftjw8QjYmuya1mPjYhZef2jgEMiYguyc7N1RHyymW1t\njglkX06NIhs5UD4CYF1nHV6Xv+HbyK7VfiiltKyxDfPh2veSfSnUkOfI3rOyxjT9/gJl/6/5F0Nb\nkw+ZbuQ9os57Gtn7Qfkw63JLgfL/ub58cH4bOs+vASPqfdHSOWUTt9VOXjeQ7HIGSWrzDLmSWkOQ\nTRqzVWSznF7ABz1VXch6DBfl6y5poPzPyK7TXZFS+t969dZ+kLwD+GpkE9NsSjbs+S95b1JXsl6K\neRHRMSIupm5PzF3AeZFNgrU1WY9PtoOI7YBNU0r1r8Fr+qCz2+AckLdnOdkw0dqhmrOBAbU91imb\n5OZ/gXGRTTizK/BvZB/O67dxK+B0Gg8Jm+fr5wHt8t7ONX1ob+o4NomIYyKiez7ccknZcRxC3eHj\nPyML5PdGxM75dYebAZ9qoL1rCiuXAHtFxJW11xBHxMDIbjdTpwctpfQkWS/xjyPiSymlGcANwO0R\n8el8/zsD9wCTUkqP0TwtMiNuPurgaurODNxg/fl5OopswqmhZY8zgK9ENmlS+faR/09dApwEnN9E\nc44jm4l5UFndg8h6Fcfk5+464I6I2C//X9ksIkZHxDlNtX8N7iELZ9VkMy6vSx3rW4aU0iusoXc2\nIj4bEV+LiF756x3Jvjz58xqq+y35JRW5pt5fAD4ZEUfk4fEssveCvzTxHnEHcGFE9IyInmR/Q2v6\nku9Z4Jj8731Efqy15gBb1PvfuYHsmv/++TH3iuz68VrDyOYP2CD34pWklmbIldQaEtm1hY8A/yS7\nNvTyfN14oBNZGPtfsplA64ehn5NNdnRbveWlW7eklB4FLiL7UP0m2QRNo/Ptfpc/ppNN6vIedYck\nX0o2LPCVfLuflbXhUFYfqtzQ8aV6ryEbnjuO7DYms8iGL56Xr7s7/zk/PphBegxZz82bZMNILy4L\nZf9BFkZeITuPd5Ndn9hwg7IZha8m+6A+myzglg+rbehev42F5mOBV/Ih5WP5YDKkOrNO50Ng9ycb\n/vgQWY/WS2QTWtW55yswNereK/a/8jr+H/CZ/FxMi4iFZBNRPQ28U7+tKaXfA0cDEyLiULIvAH5K\n9veyhOxv6jGa1ztcqpaGz0dzeh/rb3Mz0D9vW62Gjv1w4F3gZymlt2ofZJMtdSCbNCmRz5SbH9tT\nZP8b++XnoTHHA9eV152y2atvyNeRUvoG2RdK/0M2LPflvF31r4Ft1vlJ2cRH95ANp759XepoZpnG\ntq9ty//WXqNer54FZJMw/V9+XieS/f9d2WCFWW/0ovjgvs9Nvb8kstEPR5PNtH0M8KX8C6PG3iMu\nB6aQ9Rw/lz+/vF69tc4kC+YLyC7vuLesvS+RBeb/F9ns7FuSXdN/P/BIRCwme58YVlbfMWQTfEnS\nRiGyS0Ek6cMTEa8AJ61FL1r98p3IeiN2Tyn9s0Ub1/S+HwL+O2UzIrcZEXEKcFRKaW1uidPSbegD\n/D2ltFVrtUFqDZFNFHZqSumI1m5LS4uI3mS3SNotH3IvSW2ePbmSNkanAE992AE3N5l698RsDZHd\n23LvyG5LMxj4FmW9Na2kW94O6SMlpTSpiAEXIO/hH2LAlbQx6dD0JpLUdkREDdmwvJGtsf+U0g9a\nY78N6Eg2rHQ7shlP7yC7frLV5NdwzmjNNqyLiJjG6pOLQXYf4Ds+7Pa0pHwSpIYmSUspuw9roUTE\n+XwwvLfckymlQxtYLkkqIIcrS5IkSZIKw+HKkiRJkqTC2KDDlSPCbmJJkiRJKrCUUovcaq+lbPCe\n3JRSqz8uueSSVm+Dx+QxFeFRtOPxmDaeh8e0cTyKdkxFOx6PaeN5eEwbx6Nox7Sux9MWOVxZkiRJ\nklQYhlxJkiRJUmF8JEJuVVVVazehxXlMG4eiHVPRjgc8po2Fx7RxKNoxFe14wGPaWHhMG4eiHVOR\njmeD3kIoIlJbHactSZIkSVo/EUFqYxNPbdDZldfFWWdVs3Bhy9ZZUQHjx1e3bKWSJEnaqEW0qc/l\nUpu3sXRgtrmQu3AhDBhQ3aJ11tS0bH2SJEkqho3lQ7vU2jamL4U+EtfkSpIkSZI+Ggy5kiRJkqTC\nMORKkiRJkgrDkCtJkiRpjcaMGcNvfvOb1m7GRqempoZ27dqxatWq1m7KR06bm3hKkiRJai1nnXsW\nC5e18K0+ylRsVsH4749f73qef/55vv3tb/P3v/+d+fPnrxak3n77bU466SQmTZpEz549GTduHGPG\njFnr/Tz33HM899xz3HHHHQA8/vjjnHnmmbz++uu0b9+efffdlx/96Ef069evtN9TTjmFRx99lIjg\n4IMP5vrrr6dr164APPDAA5x33nm8+uqr7Lrrrvz0pz9lp512AuDWW2/lpJNOonPnzqX9P/TQQ+y7\n775AFhpPPfVU/vKXv7Dpppvy5S9/mfHjx9O+ffu1P4EqNEOuJEmSlFu4bCEDRg7YYPXX3FfTIvV0\n7NiR0aNHc9pppzFy5MjV1p922mlsttlmvPXWWzzzzDMceuihDB06lCFDhqzVfm688UaOPfbY0uud\nd96ZiRMnstVWW7Fy5UouvPBCTjnllFJP74UXXsiiRYuoqalh1apVjBo1iurqaq6++mpmzJjBscce\ny8SJE9lzzz258sorOeyww3jppZdKQXXvvffmySefbLAtp556Kn369GH27NksWLCA4cOHc91113HG\nGWes1TGp+ByuLEmSJLVBb775JqNGjaJ3795sv/32/Pd//3dp3aBBg/jqV7/aYGh99913+fWvf81l\nl11G586d2XvvvTn88MP5+c9/DsC8efP4whe+QGVlJVtssQX77rvvGm+l9Lvf/Y799tuv9Lp3795s\ntdVWAKxatYp27drxz3/+s7S+pqaGkSNH0qVLF7p168bIkSOZNm0aAA8//DD77LMPe+21F+3ateOc\nc85h5syZdUJtY7d0qqmp4eijj6Zjx4706dOHESNGlOqu7+WXX2a//fajoqKCXr16MXr06NK6M888\nk/79+9O9e3c+9alP8cc//rG0rrq6miOPPJLjjjuObt26seuuuzJjxgzGjRtHnz596N+/P5MmTSpt\nX1VVxXnnncenP/1punfvzsiRI1mwYEGDbVq0aBEnnXQS/fr1Y+utt+aiiy4q9cA31l6tPUOuJEmS\n1MasWrWKL37xi+y+++68+eabPProo4wfP55HHnmkybLTp0+nQ4cODBw4sLRs6NChpUB49dVXs802\n2zBv3jzeeustxo0b1+A9UN99911eeeUVBg8eXGf5a6+9RmVlJZ07d+bqq6/mu9/9bmndaaedxgMP\nPMDChQtZsGAB99xzD4cccgiQ3We1PMSuWrWKlBLPP/98adkzzzxDr169GDx4MJdffjnvv/9+ad1Z\nZ53FnXfeyXvvvcfMmTOZOHEin//85xs8BxdddBEjRoxg4cKFzJw5k2984xuldcOGDWPq1KksWLCA\nr3zlKxx55JGsWLGitP7BBx/k+OOPZ8GCBey+++4cfPDBQPalw8UXX8zXv/71Ovv6+c9/zi233MKs\nWbPo0KFDnX2VO/HEE+nYsSP//Oc/eeaZZ3jkkUf46U9/2mR7tfYMuZIkSVIb8/TTTzNv3jwuvPBC\nOnTowHbbbcfXvvY17rzzzibLvvPOO3Tr1q3Osq5du7JkyRIgG+o8a9YsampqaN++PXvvvXeD9Sxc\nuLBUtlz//v1ZsGAB8+bN4/LLL68TgnfffXdWrFjBFltsQc+ePdlkk0045ZRTADjwwAN54okneOKJ\nJ1ixYgXf+973WLFiBUuXLgVgv/32Y9q0acydO5d77rmHO+64gx/84AeluvfZZx+ef/55unXrxjbb\nbMMee+zB4Ycf3mDbO3bsSE1NDTNnzqRjx47stddepXXHHHMMlZWVtGvXjm9961ssX76cf/zjH6X1\n++67L8OHD6d9+/Z8+ctfZu7cuZx77rm0b9+eo48+mpqaGhYvXgxkwf34449nyJAhdO7cmcsuu4y7\n7rprtR7pOXPmMHHiRK655ho6depEr169SqG9qfZq7RlyJUmSpDbm1Vdf5c0336SysrL0GDduHG+9\n9VaTZbt06VIKYbUWLVpUCqvf+c53GDhwIAcddBA77LADV1xxRYP1VFRUAJTCcX2VlZWccMIJHH74\n4aVht0cddRSDBw/mnXfeYfHixWy//fala3oHDx7MhAkTOP300+nXrx/z589nyJAhbL311gBst912\nbLvttgDssssuXHzxxfzqV78Csl7fESNGMGrUKJYuXcq8efN4++23Oeeccxps25VXXklKiWHDhrHL\nLrtwyy23lNZdddVVDBkyhIqKCiorK1m0aBHz5s0rre/du3fpeadOnejZs2epp7tTp05A9kVCrW22\n2ab0vH///qxcubJOfZD9PleuXEnfvn1Lv8+TTz6ZuXPnNtlerT0nnpIkSZLamP79+7Pddtsxffr0\ntS47aNAg/vWvf/Hyyy+XhixPnTqVXXbZBchC8FVXXcVVV13FtGnTOOCAA9hjjz044IAD6tSz+eab\ns8MOO/CPf/xjjT2LK1eu5K233mLx4sVUVFQwdepUrr/++lIY/PrXv84+++xT2n7UqFGMGjUKyHqK\nb7rpJvbYY481Hkttj+jbb7/N66+/zumnn84mm2xCjx49OPHEE7nooosaDOl9+vThxz/+MQB/+tOf\nOPDAA9lvv/2YOXMmP/jBD3jsscfYeeedAejRo0ej1wI35bXXXqvzfJNNNqFnz568++67peXbbLMN\nm266KfPnz6ddu9X7GdfU3u23336d2/VRZk+uJEmS1MYMGzaMrl27cuWVV/Lee+/x/vvv8/zzzzNl\nypTSNsuWLStdS7p8+XKWL18OZOH0S1/6EhdffDFLly7lj3/8Iw888ADHHXcckN2W5+WXXyalRLdu\n3Wjfvv0ab8NzyCGH8MQTT5Re33vvvUyfPp1Vq1Yxd+5cvvWtb/GJT3yi1Ou7xx578JOf/IRly5bx\n3nvv8eMf/5ihQ4eWyv/tb3/j/fffZ+7cuYwdO5bDDz+cQYMGATBx4kTmzJkDwEsvvcTll19emjm6\nZ8+ebLfddlx//fW8//77LFy4kAkTJtSpu9zdd9/NG2+8AWQ90hFBu3btWLJkCR06dKBnz56sWLGC\n//iP/1it13ttpJS47bbbePHFF1m6dCkXX3wxRx555GrXOPft25eDDjqIb33rWyxZsoRVq1bxz3/+\nszTp1praq3XjmZMkSZLamHbt2vHggw/y7LPPsv3229OrVy/Gjh1bCmQ1NTV07tyZXXbZhYigU6dO\npfvNAlx33XW899579O7dm2OPPZYbbrihtH7GjBkMHz6crl27stdee3HaaafVmUG53NixY7n99ttL\nr2fOnMmIESNKMw936NCBe++9t7T+5ptvpqamhq233pqtt96ampoaJkyYUFp/1llnUVlZyY477sgW\nW2zBT37yk9K6xx57jKFDh9KlSxcOPfRQRo0axfnnn19a/+tf/5qJEyfSq1cvPvaxj7HppptyzTXX\nNNjuKVOmsOeee9K1a1cOP/xwrr32WgYMGMCIESMYMWIEgwYNYsCAAXTq1In+/fuXykXEagG1sdcR\nwXHHHceJJ55I3759WbFiBddee22D2/7sZz9jxYoVDBkyhB49enDkkUcye/bsRturdRPr0zXfZOUR\naW3rP/HEagYMqG7RdtTUVHPrrS1bpyRJkjZu9Wf7BTjr3LNYuGzhBttnxWYVjP/++A1W/4ZwzDHH\ncNRRR61xkqePsv3335/jjjuOf/u3f2vtpmxwDf2/lC1ffXruVuQ1uZIkSVJuYwugH4bynlytbkN2\nGmrdOFxZkiRJktZRQ/cYVuuyJ1eSJEmS1sHjjz/e2k1QA+zJlSRJkiQVhiFXkiRJklQYzQq5EVER\nEb+KiBcj4oWI+HRE9IiISRExPSIeiYiKDd1YSZIkSVLb1tr5sbk9uT8EfptS2gnYFXgJOBeYlFIa\nBDyav5YkSZIkfbS1an5sMuRGRHdgn5TSzQAppX+llBYBhwG1d3aeAIzcUI2UJEmSJLV9bSE/Nqcn\ndztgbkTcEhF/j4ifRMTmQJ+U0px8mzlAnw3VSEmSJEnF9vDDD3PEEUe0djM2SlVVVdx0003rVcfZ\nZ5/NDTfc0BLNafX82JxbCHUAPgGcnlJ6OiLGU69rOaWUIsK7IEuSJGmjdtZZ1SxcuOHqr6iA8eOr\nN9wONoCxY8fy5JNPMmPGDG6++WZOOOGEOuuvueYarrzySpYuXcqXv/xlrr/+ejp27LjW+7ngggu4\n7rrrVlv+xBNPsP/++3PBBRdw2WWXATB79mzGjh3L3/72N2bNmkVNTQ39+/cvlTn77LO5//77mT17\nNltttRXnn38+xx13XLOO6fnnn+fb3/42f//735k/fz6rVq1a62P5sEXEet+v9+yzz2bYsGGcdNJJ\nbLLJJutTVavnx+aE3DeAN1JKT+evfwWcB8yOiC1TSrMjoi/wVkOFq6urS8+rqqqoqqparwZLkiRJ\nG8rChTBgQPUGq7+mZsPVvaHstttujB49mnPOOWe1IPXwww9zxRVX8Pjjj9O3b1+OOOIILrnkEsaN\nG7dW+3j66adZvHgxw4YNq7N85cqVnHnmmey555519t2uXTsOOeQQzj//fPbaa6/V6uvSpQsPPvgg\ngwYN4qmnnmLEiBEMHDiQz3zmM00eU8eOHRk9ejSnnXYaI0d+dK7I3HLLLdlxxx25//77GTVq1Bq3\nmzx5MpMnT26sqvXKjy2hyeHKKaXZwOsRMShfdCAwDXgAqP3K4wTgvobKV1dXlx4GXEmSJKl5BgwY\nwNVXX83QoUOpqKhg9OjRLF++vLT+Jz/5CR/72MfYYostOPzww5k1a1ZpXbt27bjxxhsZNGgQlZWV\nnH766WvcT0qJ73//+wwcOJCePXty9NFHs2DBgtL6U089lQMOOIDNNttstbITJkzga1/7GjvttBMV\nFRVcfPHF3HrrraX1V1xxBVtvvTXdunVjxx135LHHHmuwDRMnTmwwK1x99dWMGDGCwYMHk9IHHX+9\ne/fm5JNP5lOf+lSD9VVXVzNoUBZfhg0bxj777MOf//znZh3ToEGD+OpXv8qQIUMarLu+b37zm/Tp\n04fu3btHIA2RAAAgAElEQVSz6667Mm3aNAAeeughdt99d7p3707//v259NJLS2Vqampo164dt956\nK/3796dHjx7ceOONPP300+y6665UVlZyxhlnlLa/9dZb2XvvvTnjjDOoqKhgp512WuO5BLj55psZ\nMmQIPXr0YMSIEbz22mtNtheyTsmHHnqo0eOtqqqqk/HqW9/82BKaO7vyGcDtETGVbHas/wS+DwyP\niOnAAflrSZIkSS0gIrj77rt5+OGHeeWVV3juuedKAfKxxx7j/PPP5+6772bWrFlsu+22jB49uk75\nhx56iClTpvDcc89x11138fDDDze4n2uvvZb777+fJ598klmzZlFZWclpp53WrDa+8MILDB06tPR6\n1113Zc6cOSxYsIB//OMf/M///A9Tpkxh8eLFPPLIIwwYMKDBep5//nkGDx5cZ9mrr77KLbfcwkUX\nXVQn4K6t9957j6effppddtllnetYk4cffpg//OEPzJgxg0WLFnH33XezxRZbAFlv8m233caiRYt4\n6KGHuP766/nNb35Tp/xTTz3Fyy+/zC9/+UvOPPNMxo0bx2OPPca0adO46667ePLJJ+tsO3DgQObP\nn8+ll17Kl770JRY2MLb+N7/5DePGjePee+9l3rx57LPPPowZM6bJ9gLsuOOOTJ06tSVOTavmx2aF\n3JTS1JTSHimloSmlL6WUFqWU3k4pHZhSGpRSOiiltAGvXpAkSZI+er7xjW+w5ZZbUllZyRe/+EWe\nffZZAG6//XZOOukkdtttNzp27Mi4ceP485//XKfH7txzz6Vbt25ss8027L///qWy9d14441cfvnl\n9OvXj0022YRLLrmEX/3qV826FvWdd96he/fupdfdunUDYMmSJbRv357ly5czbdo0Vq5cSf/+/dl+\n++0brGfhwoV07dp1tWO//PLL2XzzzdfrmtOTTz6Z3XbbjYMOOmidyjemY8eOLFmyhBdffJFVq1Yx\nePBgttxySwD2228/dt55ZwA+/vGPM3r0aJ544ok65S+66CI6duzI8OHD6dKlC2PGjKFnz57069eP\nffbZh2eeeaa0be/evTnzzDNp3749Rx11FIMHD+bBBx9crU033HAD5513HoMHD6Zdu3acd955PPvs\ns7z22muNthega9euDQbntdXa+bG5PbmSJEmSPmTlAaRTp068++67AKXe21qbb745W2yxBTNnzmyw\nbOfOnXnnnXca3EdNTQ1HHHEElZWVVFZWMmTIEDp06MCcOXMa3L5cly5dWLx4cen1okWLgCwsDRw4\nkPHjx1NdXU2fPn0YM2ZMnSHV5SorK+vU88ADD/DOO+9w5JFHAtmQ6nXpzf3Od77DCy+8wF133bXW\nZZtj//335/TTT+e0006jT58+fP3rX2fJkiUA/PWvf2X//fend+/eVFRUcOONNzJ//vw65fv0+WCC\n4U6dOq32uvb3DbDVVlvVKbvttts2eD5fffVVzjzzzNLvs7an9s0332y0vZB9OVFRUbEeZ6RtMORK\nkiRJG5l+/fpRU1NTev3uu+8yf/781YJQc/Tv35/f/e53LFiwoPRYunQpffv2bbLszjvvXKeHeOrU\nqfTp04fKykoAxowZwx/+8AdeffVVIoJzzjmnwXp23XVXpk+fXnr92GOPMWXKFPr27Uvfvn256667\nGD9+/FrdYuiSSy7h4Ycf5pFHHqFLly7NLre2zjjjDKZMmcILL7zA9OnT+cEPfgDAV77yFUaOHMkb\nb7zBwoULOfnkk9drpubyLzAgC7P9+vVbbbv+/fvz4x//uM7v891332XPPfdstL0AL774Irvttts6\nt7GtMORKkiRJG4na3swxY8Zwyy23MHXqVJYvX87555/PnnvuWec2Og2Va8jJJ5/M+eefXxrqPHfu\nXO6///7S+pUrV7Js2TJWrVrFihUrWLZsWam+448/nptuuokXX3yRBQsWcNlll/HVr34VgOnTp/PY\nY4+xfPlyNt10UzbbbDPat2/fYBsOOeSQOkN5L7vsMmbMmMHUqVN59tlnOeywwxg7diy33HJLaZtl\ny5axbNmy1Z4DjBs3jjvuuINJkyaVAne5xo6ptr4VK1YAsHz58joTfpWbMmUKf/3rX1m5ciWdO3eu\nc4zvvPMOlZWVdOzYkaeeeopf/OIXaz3kurxNb731Ftdeey0rV67k7rvv5qWXXuKQQw5ZrczJJ5/M\n9773PV544QWA0rW3TbUXsts1ff7zn1+rNrZFhlxJkiRpI1B+XernPvc5LrvsMkaNGkW/fv145ZVX\nuPPOO+tsu6ay9Z155pkcdthhHHTQQXTr1o3PfOYzPPXUU6X1w4cPp3PnzvzlL39h7NixdO7cmT/8\n4Q8AHHzwwXz3u99l//33Z8CAAeywww6lWYSXL1/OeeedR69evejbty/z5s1b462Famchrt1vly5d\n6N27N71796ZPnz506tSJzTffvM5Q2s6dO9OtWzcigh133JHNN9+8tO6CCy7g9ddfZ+DAgXTt2pWu\nXbvy/e9/MM9RY8dUU1ND586d2WWXXYgIOnXqxE477dRguxcvXszYsWPp0aMHAwYMoGfPnnznO98B\n4LrrruPiiy+mW7duXHbZZRx99NGr/U6aUr7Npz/9aWbMmEGvXr246KKLuOeeexoM8CNHjuScc85h\n9OjRdO/enY9//OOlSccaa++sWbN48cUXC3HbpFifmcqarDwirW39J55Y3eL3JqupqebWW1u2TkmS\nJG3cImK1Hs6zzqqmBebdWaOKChg/vnrD7WAjNmnSJK677jruvffe1m5Km3Prrbdy0003lYL4hnD2\n2WczcOBATj755AbXN/T/UrZ83WYF20A6tHYDJEmSpLbCANp6hg8fzvDhw1u7GR9ZV111VWs3ocU4\nXFmSJEmS2rD1uYXSR5EhV5IkSZLasBNOOIEnn3yytZux0TDkSpIkSZIK4yNxTe5Tf3uKE886sUXr\nrNisgvHfH9+idUqSJEmS1s9HIuSueH8FA0YOaNE6a+6radH6JEmSJEnrz+HKkiRJkqTC+Ej05EqS\nJEkNccZaqXgMuZIkSfpISim1dhMkbQAOV5YkSZIkFYYhV5IkSZJUGIZcSZIkSVJhGHIlSZIkSYVh\nyJUkSZIkFYYhV5IkSZJUGIZcSZIkSVJhGHIlSZIkSYVhyJUkSZIkFYYhV5IkSZJUGIZcSZIkSVJh\nGHIlSZIkSYVhyJUkSZIkFYYhV5IkSZJUGIZcSZIkSVJhGHIlSZIkSYVhyJUkSZIkFYYhV5IkSZJU\nGIZcSZIkSVJhGHIlSZIkSYVhyJUkSZIkFYYhV5IkSZJUGIZcSZIkSVJhGHIlSZIkSYVhyJUkSZIk\nFYYhV5IkSZJUGIZcSZIkSVJhGHIlSZIkSYVhyJUkSZIkFYYhV5IkSZJUGIZcSZIkSVJhGHIlSZIk\nSYVhyJUkSZIkFYYhV5IkSZJUGIZcSZIkSVJhGHIlSZIkSYVhyJUkSZIkFUaH5mwUETXAYuB9YGVK\naVhE9AB+CWwL1ABHpZQWbqB2SpIkSZI2Aq2dH5vbk5uAqpTS7imlYfmyc4FJKaVBwKP5a0mSJEnS\nR1ur5se1Ga4c9V4fBkzIn08ARrZIiyRJkiRJG7tWy49r05P7+4iYEhH/ni/rk1Kakz+fA/Rp8dZJ\nkiRJkjY2rZofm3VNLrB3SmlWRPQCJkXES+UrU0opIlLLN0+SJEmStJFp1fzYrJCbUpqV/5wbEfcC\nw4A5EbFlSml2RPQF3mqobHV1del5VVUVVVVV69tmSZIkSVIrmDx5MpMnT250m/XJjy2hyZAbEZ2B\n9imlJRGxOXAQcClwP3ACcEX+876GypeHXEmSJEnSxqt+x+Wll15aZ/365seW0Jye3D7AvRFRu/3t\nKaVHImIKcFdEnEQ+BfSGaqQkSZIkaaPQ6vmxyZCbUnoF2K2B5W8DB26IRkmSJEmSNj5tIT+uzS2E\nJEmSJElq0wy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrD\nkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTC\nMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSp\nMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJ\nKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJ\nkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJ\nkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJ\nkiSpMAy5kiRJkqTCMORKkiRJkgqjWSE3ItpHxDMR8UD+ukdETIqI6RHxSERUbNhmSpIkSZI2Fq2Z\nIZvbk3sm8AKQ8tfnApNSSoOAR/PXkiRJkiRBK2bIJkNuRGwNHAL8FIh88WHAhPz5BGDkBmmdJEmS\nJGmj0toZsjk9udcA3wFWlS3rk1Kakz+fA/Rp6YZJkiRJkjZKrZohOzS2MiK+ALyVUnomIqoa2ial\nlCIiNbQOoLq6uvS8qqqKqqoGq5EkSZIktXGTJ09m8uTJa1zfEhlyfTUacoG9gMMi4hBgM6BbRPwc\nmBMRW6aUZkdEX+CtNVVQHnIlSZIkSRuv+h2Xl156af1N1jtDrq9GhyunlM5PKW2TUtoOGA08llI6\nDrgfOCHf7ATgvg3VQEmSJEnSxqEtZMi1vU9ubZfy94HhETEdOCB/LUmSJElSuQ89QzY1XLkkpfQE\n8ET+/G3gwA3VKEmSJEnSxq21MuTa9uRKkiRJktRmGXIlSZIkSYVhyJUkSZIkFYYhV5IkSZJUGIZc\nSZIkSVJhGHIlSZIkSYVhyJUkSZIkFYYhV5IkSZJUGB1auwGSJEmSJNUXEb2BbwCdgetTSjOaU86e\nXEmSJElSW3Q18AhwL/CL5hYy5EqSJEmSWl1EPBwR+5Yt6gi8kj82bW49hlxJkiRJUltwNHBYRNwZ\nETsAFwLjgGuBU5tbidfkSpIkSZJaXUppIXB2HnAvB94EzkgpLVibegy5kiRJkqRWFxEDgZOBFcDZ\nwA7AnRHxEPA/KaX3m1OPw5UlSZIkSW3BHWSTTE0GfpZSehIYASwCJjW3EntyJUmSJEltQe1EU5uT\n3TaIlFICJkTE3c2txJArSZIkSWoLTgX+G1hJNmy5JKW0tLmVGHIlSZIkSa0upfQn4E/rW4/X5EqS\nJEmSCsOQK0mSJEkqDEOuJEmSJKnNiIiPr095Q64kSZIkqS25PiKejohTI6L72hY25EqSJEmS2oyU\n0meBY4D+wN8j4o6IOKi55Q25kiRJkqQ2JaU0HbgQOAfYD/hhRPwjIkY1VdaQK0mSJElqMyJiaERc\nA7wIHAB8IaW0E7A/cE1T5b1PriRJkiSpLbkWuAm4IKW0tHZhSunNiLiwqcKGXEmSJElSW3Io8F5K\n6X2AiGgPbJZSejel9LOmCjtcWZIkSZLUlvwe6FT2ujMwqbmFDbmSJEmSpLZks5TSO7UvUkpLyIJu\nsxhyJUmSJEltybsR8cnaFxHxKeC95hb2mlxJkiRJUltyFnBXRMzKX/cFjm5uYUOuJEmSJKnNSCk9\nHRE7AYOBBPwjpbSyueUNuZIkSZKktuZTwHZkmfUTEUFzZlYGQ64kSZIkqQ2JiNuA7YFngffLVhly\nJUmSJEkbnU8CQ1JKaV0KO7uyJEmSJKkteZ5ssql1Yk+uJEmSJKkt6QW8EBFPAcvzZSmldFhzChty\nJUmSJEltSXX+MwFR9rxZDLmSJEmSpDYjpTQ5IgYAA1NKv4+IzqxFdvWaXEmSJElSmxERY4G7gRvz\nRVsD9za3vCFXkiRJktSWnAZ8FlgMkFKaDvRubmFDriRJkiSpLVmeUqqdcIqI6MBaXJNryJUkSZIk\ntSVPRMQFQOeIGE42dPmB5hY25EqSJEmS2pJzgbnA/wFfB34LXNjcws6uLEmSJElqM1JK7wM/zh9r\nzZArSZIkSWozIuKVBhanlNL2zSlvyJUkSZIktSV7lD3fDPgysEVzC3tNriRJkiSpzUgpzSt7vJFS\nGg8c2tzy9uRKkiRJktqMiPgkH9wyqB3wKaB9c8sbciVJkiRJbcnVfBBy/wXUAEc1t7AhV5IkSZLU\nZqSUqtanfKMhNyI2A54ANs23/VVKqToiegC/BLYlT9UppYXr0xBJkiRJ0satJTJkRHybD3pyS4vz\nnyml9F+NtaHRiadSSsuA/VNKuwG7ASMi4tNkN+edlFIaBDyav5YkSZIkfYS1UIb8JHAKsBWwNXAy\n8AmgC9C1qTY0OVw5pbQ0f9oR2IQsUR8G7JcvnwBMbqKRkiRJkqSPgBbIkNsAn0gpLQGIiEuA36aU\njmnO/psMuRHRDvg7sAPwo5TSUxHRJ6U0J99kDtCnOTtTyznr3LNYuKxlR4hXbFbB+O+Pb9E6JUmS\nJH20tECG7A2sLHu9Ml/WLM3pyV0F7BYR3YF7I2KXeutTRNQfL11SXV1del5VVUVVVVVz26ZGLFy2\nkAEjB7RonTX31bRofZIkSZKKZfLkyUyePLnRbdY3QwI/A56KiF+TXYs7kqz3t1maPbtySmlRRDwO\nHAzMiYgtU0qzI6Iv8NaaypWHXEmSJEnSxqt+x+Wll166xm3XNUOmlP4zIn4HfDZfdGJK6ZnmtrHR\niaciomdEVOTPOwHDgReB+4ET8s1OAO5r7g4lSZIkScXUghmyM7AkpfRD4I2I2K65bWiqJ7cvMCEi\n2pMF4l+mlH4bEX8B7oqIk1jLG/NKkiRJkgprvTNkRFSTzbA8GLiZbAKr24C9m9OARkNuSun/yKZq\nrr/8beDA5uxAkiRJkvTR0EIZ8ghgd+BvedmZEdHkrYNqNTpcWZIkSZKkD9nyfPIqACJi87UpbMiV\nJEmSJLUld0fEjUBFRIwFHgV+2tzCzZ5dWZIkSZKkDSkiAvglsCOwBBgEXJRSmtTcOgy5kiRJkqS2\n5LcppV2AR9alsMOVJUmSJEltQkopAX+LiGHrWoc9uZIkSZKktmRP4NiIeBV4N1+WUkq7NqewIVeS\nJEmS1Ooion9K6TXgYCABsS71GHIlSZIkSW3Bb4DdU0o1EXFPSmnUulTiNbmSJEmSpLZm+3UtaMiV\nJEmSJBWGw5UlSZIkSW3BrhGxJH/eqew5ZBNPdWtOJYZcSZIkSVKrSym1b4l6HK4sSZIkSSoMQ64k\nSZIkqTAMuZIkSZKkwjDkSpIkSZIKw5ArSZIkSSoMQ64kSZIkqTAMuZIkSZKkwjDkSpIkSZIKw5Ar\nSZIkSSoMQ64kSZIkqTAMuZIkSZKkwjDkSpIkSZIKw5ArSZIkSSoMQ64kSZIkqTAMuZIkSZKkwjDk\nSpIkSZIKw5ArSZIkSSoMQ64kSZIkqTAMuZIkSZKkwjDkSpIkSZIKw5ArSZIkSSoMQ64kSZIkqTAM\nuZIkSZKkwjDkSpIkSZIKw5ArSZIkSSoMQ64kSZIkqTA6tHYDPgrOOquahQtbts6npk5nwMgBLVup\nJEmSJG3kDLkfgoULYcCA6hat849P/bFF65MkSZKkInC4siRJkiSpMAy5kiRJkqTCMORKkiRJkgrD\nkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTC\naDLkRsQ2EfF4REyLiOcj4hv58h4RMSkipkfEIxFRseGbK0mSJElqq9pCfmxOT+5K4JsppZ2BPYHT\nImIn4FxgUkppEPBo/lqSJEmS9NHV6vmxyZCbUpqdUno2f/4O8CKwFXAYMCHfbAIwckM1UpIkSZLU\n9rWF/LhW1+RGxABgd+CvQJ+U0px81RygT4u2TJIkSZK00Wqt/NjskBsRXYB7gDNTSkvK16WUEpBa\nuG2SJEmSpI1Qa+bHDs3ZKCI2IWvgz1NK9+WL50TEliml2RHRF3irobLV1dWl51VVVVRVVa1XgyVJ\nkiRJrWPy5MlMnjy50W3WJz+2hCZDbkQEcBPwQkppfNmq+4ETgCvyn/c1ULxOyJUkSZIkbbzqd1xe\neumlddavb35sCc3pyd0bOBZ4LiKeyZedB3wfuCsiTgJqgKM2SAslSZIkSRuLVs+PTYbclNIfWfO1\nuwe2bHMkSZIkSRurtpAf12p2ZUmSJEmS2jJDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJ\nKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJ\nkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJ\nkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJ\nkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJ\nkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORK\nkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5\nkiRJkqTCMORKkiRJkgrDkCtJkiRJKgxDriRJkiSpMAy5kiRJkqTCaDLkRsTNEfH/27vzcDuqKv3j\n35cAMkoQBRXU0AgKNoiASKMtg4LY2ooDOCAEaGknVLAdaOTXBieCIkSlgVaZRMFGRURxAJWgOBBF\nZEZsJUzKoBKVSUjy/v7YdeDk5iaQc05Sd1fez/P4pE4V97jquefUrVV777Vuk3RF377HSDpf0nWS\nzpM0eemGGRERERERERPdRMgfH8lI7snAbmP2HQKcb3sT4PvN64iIiIiIiFi+tZ4/PmySa/tHwJ1j\ndr8MOLXZPhXYfcRxRURERERERGUmQv446Jrc9Wzf1mzfBqw3ongiIiIiIiKiW5Zp/jh04SnbBjyC\nWCIiIiIiIqLDlkX+uOKAP3ebpMfbvlXSE4DbF/UfTps27cHtHXfckR133HHA/8uIiIiIiIho08yZ\nM5k5c+aS/tgjzh9HYdAk9xxgKnBk8+/Zi/oP+5PciIiIiIiIqNfYgcvDDz/8kfzYI84fR+GRtBA6\nA/gJ8DRJN0naD5gO7CLpOmDn5nVEREREREQsxyZC/viwI7m2X7eIQy8ccSwRERERERFRsYmQPw46\nXTmWcwcdNI05c0b7npMnw4wZ00b7phERERERsVxJkhsDmTMHpkyZNtL3nD17tO8XERERERHLn6Fb\nCEVERERERERMFElyIyIiIiIiojOS5EZERERERERnJMmNiIiIiIiIzkiSGxEREREREZ2RJDciIiIi\nIiI6I0luREREREREdEaS3IiIiIiIiOiMJLkRERERERHRGSu2HUBEz6xLZrHvQfuO9D0nrzKZGdNn\njPQ9IyIiIiJi4kqSGxPG/fPuZ8ruU0b6nrPPnj3S94uIiIiIiIkt05UjIiIiIiKiM5LkRkRERERE\nRGckyY2IiIiIiIjOSJIbERERERERnZEkNyIiIiIiIjojSW5ERERERER0RpLciIiIiIiI6IwkuRER\nEREREdEZSXIjIiIiIiKiM5LkRkRERERERGckyY2IiIiIiIjOSJIbERERERERnZEkNyIiIiIiIjoj\nSW5ERERERER0RpLciIiIiIiI6IwkuREREREREdEZSXIjIiIiIiKiM5LkRkRERERERGckyY2IiIiI\niIjOSJIbERERERERnZEkNyIiIiIiIjojSW5ERERERER0RpLciIiIiIiI6IwkuREREREREdEZSXIj\nIiIiIiKiM5LkRkRERERERGes2HYAEV120CEHMee+OSN9z8mrTGbG9Bkjfc+IiIiIiK5IkhsBHHTQ\nNOaMNhcFYNZls9jzmF1H+p6zz5490veLiIiIiOiSJLkRwJw5MGXKtJG/70WzLhr5e0ZERERExKJl\nTW5ERERERER0RpLciIiIiIiI6IwkuREREREREdEZSXIjIiIiIiKiM5LkRkRERERERGckyY2IiIiI\niIjOSJIbERERERERnZE+uRHxiB10yEHMuW/OyN938iqTmTF9xsjfNyIiIiKWP0lyI+IRm3PfHKbs\nPmXk7zv77Nkjf8+IiIiIWD4NleRK2g2YAUwCPmf7yJFEFRFDO+igacwZ8aDrrMuuWypJbkRERER0\nR9t54sBJrqRJwLHAC4FbgJ9LOsf2NaMKblTuvfvetkMYuZxTHdo8pzlzYMqUaSN9z/MvOH+k7zcR\nzJw5kx133LHtMEYq51SHnNPE17XzgZxTLXJOdejaOY3qfCZCnjjMSO62wP/Zng0g6UvAy4GJl+Te\n08HkKedUha6dU9fOB+CQww7h6ds8faTv2fYa46790YWcUy26dk5dOx/IOdUi51SHrp3TCM+n9Txx\nmCR3feCmvtc3A88ZLpyIiEVbGlOwf/t/f2K3D08Z6XtmjXFEREQsx1rPE4dJcj2yKCIiHoGlMQV7\n3rxzRvp+EREREcu51vNE2YPFIGk7YJrt3ZrX/wnM719ULKn1E4yIiIiIiIilx7Z6248kT1zahkly\nVwR+DbwA+D0wC3jdRCw8FREREREREUvfRMgTB56ubHuupAOB71JKQ5+YBDciIiIiImL5NRHyxIFH\nciMiIiIiIiImmhXaDiAeGUkrjbPvsW3EEhGxLHXtWidpLUlbS1q77Vii2yTtIOlpzfbzJL1H0kva\njmGaBVIAAB6NSURBVCsiYmnrVJIr6VGSVuh7vbOkd0t6cZtxDUPSTpJuBm6VdJ6kDfsOn99WXLEg\nSetI+oCkN0paQdL7JZ0r6eM13shKeqWkdZrtdSV9XtKVkv5X0gZtxzcoSbtJ+jdJU8bs37+diEZP\n0lZtxzAMSS+WdL2kiyQ9S9JVwMWSbpH0wrbjG4SkL/YSdUkvAq4AjgQuk7Rnq8ENQdKjJW00zv4t\n2ohn1CR9tO0YhiHpk8ARwBckfQj4GLAKcLCko1oNLh4kaUVJb5b0YUnPHXPssLbiGjVJ17UdwzAk\nbSTp5Ob3tKakz0q6StKXx95T1EjSxpJeLWmztmMZlU5NV5Z0ObCD7TslvQd4BfAtYAfgEtuHtBrg\nACT9ApgKXA28CpgO7G37p5Iutf2sVgMcEUk/sL1z23EMStK3gcuBRwObUm5ivwzsAmxh++UthrfE\nJF1je9Nm+0zgp8BXKAUE9rK9S5vxDULSEcBzgV8C/wp80vanmmNVfpf6ElpRyvULOIdyftj+ZUuh\nDUzSZcBrgcnAucC/2P6ZpE2B0yv9PV1p+x+b7Z9Sim/MbhLfH9iuLilskvMZwO3ASsB+tmc1x6r7\nPkn69Di79wE+D9j2O5ZxSEOTdDXwj8CqwC3A+rbvbmaG/cr2M1oNcACS3g58yfYdkp4KnARsQSlw\n80bbV7Qa4AAknUj5Hf0ceANwoe13Nceq+y4BSPobD/1N6lkNuIfyfXp0K4ENQdKPgNMpf5veAJwM\nnEm5z9urtntYSTOBV9v+o6S9gf8H/JDSy/azvfujmg3TJ3ciWsH2nc32a4Hn2b5X0nTgUqC6JBdY\n2fZVzfZXJF0DnCXpfW0GNQxJV7DwxW+T3v4ab/iAJ9p+sSQBt9jesdn/w+amvTb9szw2st0bbTpF\n0sFtBDQC/wo8y/YDkqYBZ0j6B6DW8wH4BfAz4O99+x4DfKLZ3mmZRzS8eb3iFJLutv0zANvXNN+v\nGknSWrb/AswDbgJobi4mtRvawN4PbG37D5K2BT4v6VDbZ7Ud2IBeAVwInNe8FuU+4hetRTS8+ZS/\ntfOaf923v9bv0lts9x5IfAo4BjibMphxAuVBZm22tb05gKRjgeMknQW8vt2whnIyJRl8r+1bm2v3\n72xv+DA/N5GtYft4AElvtd2bDXFi8/ClNo+1/cdm+53AP9n+k6TVgIsp36+qdWq6MvA3SZs323dQ\nnoxBecpc6wX9fkmP771oEt4XAIcDG7cW1XCup4x07gm8lJJ83N5sv6zFuIYhSY8BngSs3ptW3ozU\nLLSeugIXSvqgpFWBmZJeCWX6PDCn3dAGNsn2AwC251A+d4+mjLiv3GZgQ9gDmAt83PZOtncCbu3b\nrtFfJL1J0nuBOyUdLGl9SVOBu9oObkCHAxc00+J/DJwpaV9JpwDfaTWywU2y/QeAZgR3J+D9kt7Z\nblgD2wz4I7AbcL7tU4C7bJ9q+9RWIxvct4AfARcBJ1I+d4dRPnM/bDOwIfQ/FHqc7a+5mAms2VJM\nw3rwHsH2A7YPAC4Dvg+s0VpUQ2hmPnwKOL25JnQh35gv6WnNQ71VJT0byjRf6jy/B/qWn/2NMsoO\n5aF5jeezkK5NV94COI0ybdTA8ygX8s2Bo21/scXwBiJpF+AO278as38ycKDtD7cT2XCapOlg4Cjb\nX5d0fc1P+CS9jjJ1T8BbgTc3hzYDDrf9P23FNghJK1NGavZrdm1AuQB+A3if7Rvbim1Qks4FPmb7\nwjH7PwwcarvKi7qkNYEPAesD7wZmVv5dejJwGGW0aRplNGN/4EbgP2ptVdfcCB1AeTi5EmU092zb\n3201sAFJ+gll6cxv+/Y9Gvga8M+2q3xwJGlr4ChKgnig7ae0HNJQJG1PmSH102Z67yuAG4Cv2J7f\nbnRLTtJHKNe6D1JG2u8FzgJ2Bl5l+6UthjcQSV8EvmD722P2vxE43naND8oBaGaqHAi8Gniq7Se0\nHNLAJL0AOJ7yt+kAyj3sFsBawAG2z24xvCUmaUfgv4GvUmaAbUWZyfI84Dt9I9XV6lSSCw82H96V\nBW8kzuubxhwThKQ1KDfn/wBsY3v9lkMaSvPZUzMddiXgmcDvbf++5dCG0jxQWRH4kyu+YDSj0ti+\nd5xjG9i+edlHNTrN+tyjgWfYflzb8US3SdoSuNv2b8bsXxnY0/YX2olseCoFLN8KbGf7DW3HM0qS\nHmf7jrbjGIak/SgPkjcCHgXcTJmyPL1ZEhATjKQnAlva/lbbsYySpMcBd9qe23Ysg2ju717PgjnT\n121f22pgI9K5JHd5IunbtqutHN3T3CxtZ/uEtmMZpWbNxnFtxzEMSdtQpmDPA66r/cLXrAvahjIy\n3Ylz6tec35q2/9p2LINqZnlc2KwNWpcyqrYVcBVlJLe6hxFN0rQHZQSgV8Dt5cA1wAk1jqgtDyRt\nbfuStuMYlEpnieMoRafeQZnptgolMdzX9vdaDC8WoakV8Szgqpr/PjUJ1G6UkXcoDyO+2ywXqpKk\ntYAXU87JlO9W1efUZZ1KciXtZvs7zfZkSvGVbSnrPw+2fVub8Q2imTo13i9JwLm2Hz/OsSpIWqm3\nRrJvX/9C+GpI+o9xdh8KfATA9tHLNqLhSNqB8v2ZA2wN/IRSROIByhTFm1oMbyAdPad1KFPBbqFU\nGf1PYHtKNfaP1jiDRd2s7H088DjK2u+/UhKNr1PqENxqu7p1rJLupExzO4NSIbrqmwmNX6n86zR1\nIpxK5ROCpJdRZufd13YsoyLpbNu7N9svpyx9mkkponWE7ZNbDG8gkvYBPkBpddl7MPkkSiXiw2tc\n597Fc1oUSZ+x/e9txzGsriW5D5ZaVynJ/gfgc5Q1KDv0LiI1kTSPRReI2M72qos4NmE1xYtOoxQG\nuwR4k+3rm2O1lsu/i3ITcXVvF6Va3QwA24e3FNpAJP0K2MWlTcOGwDG2d2/WiL/H9q4th7jEOnpO\nnWpdBSDp17af1mxfYnvrvmOX2X5me9ENRk0LoWYZw23AE2z/vVnicKmbyqo1kfRr4NOUqW5TKJ+7\nM9xUw66NpPksXKl8u2YfNRZyk/RL21s12zfZflLfsV/Z3rK96AYj6V5KfYhvUR6wfNf2vHajGs6Y\ne9efAq+3fb3qbjF2HaVq9Jwx+9cGZtmurnBq185JpVjquIeAy2tfQgjdayHUbxvK/H8Dx0jat+V4\nBnUtJQlcqIm2pOpGnhofB17EQ71/z5e0t+2fthvWUDajrIdcHZhm+x5JU2tLbvus0Ldu60bgKQC2\nz5f0yfbCGkoXz6lrraugqewNHEFT2dv2Waq7svdcKJVTJf3c9t+b13Ob5KpG99g+FjhW0lMoI4bH\nNTd8Z9g+tN3wltgelAeTH++tG2wKIlaX3Pb5i6Q3UQrj3KnS/u1M4IXUW6n8WkqRqT0ohfZOUWm3\nc4bHFBWs1Mq9h/4uLcZqvT4sSndG1h5S6zn9kVKEbjydqOvRtST3cZLeRXkKsdaYY7W2EJrGokt5\nV9ecvtG53r8u1YZfLWl34HuSjmk7piFd0syGuIAyXe8CAEmrU29p+S6ek5qnsWvQtK7qGwGotSLn\ngZTK3r9uXh8sqVfZe+/WohrOrZLWsH2X7Rf1dkp6AguOHFbJ9g3AkcCRkp4OvKblkJaY7a9KOg/4\nUFPY6N1txzQCU3moUvmulFH371Ie8h3QYlxDaZZhfAb4TPMd2pPy2Vu/f7S6IltI+luzvYqkJ7j0\nn34U9f5t+gjlb+55LDi1d1dKwdEade2cfge8oLl+L6DiQbQFdG268jQWfKJyvO3bm4vgkbb3aSey\n0ZH0zzTrjG2f93D//UQk6RfAS23f2rdvA8p0341sV9kXrkelavQ0yrSW57cczkBUKqQeQJkCexlw\nku15KhWK17M9u834BtHRc+pU66qx1JHK3ovSPGBZo9J6EUfbflfbcSwNSqXyCWtxS5okTanxOr4o\nzfVvM9s/aTuWQTQPYF8EPLHZdQtlPfWf24tqOF06J0kHAhd5TIvS5tg7bH+qhbBGqlNJLkBTUGF9\n4Ge27+rb/2KP6UFWA0mzbG/bbB8AvI3Sh3BX4Ju2j2gzvkGoo71/I9qghVtXbUmZulxl6ypJW9i+\nvO04liaV3sYbA78bu74rJgaVithruvKWNJJ61W2/358AStrf9kmtBTYgSTvZvqDtOCJUKi1vDPy2\nxiKPy4Nap0GMS9I7KL3SDgSuaqaO9ny0naiG1j/l8E2UwjmHU5LcvdoJaTi2zx/vyZHtObUmuJIm\nS5ou6VpJd0r6c7M9vUneq9K183k4TQGnWs2ntEOCMqI7H6i58uilkn4j6UOSNms7mFGQdFzf9vMo\n7ZA+AVwp6SWtBTYkSbtJOkHSN5r/ndAkVdWzPb+X4Er6r7bjGYSkIyhV/jcHvt/cI/W8vZ2ohrO8\nJbiSrmg7hkFI2lTStyWdK2kjSadImiNpVjMYVR1JX1Tpi4ukF1EKPU4HLpO0Z6vBDUjSoyVtNM7+\n6oqdjadra3L/Hdja9l2SplDWe06xPaPdsIYyqZkeIWBSr3CO7bsl1dx8+hBgd2A9yhTz23momXuN\nIxtnAt8HdgRus+1mmvzU5lhtlXu7dj79LUIWOkTpSVid5kHe/wDzJb2ZckN7F/B0SW+xfU6rAQ7m\ncsra29cD5zTrcU8HvlTxVMR/6tv+MLC77V+q9MP8MmWpRlVUirVtDHyeMmUPSv/pd0j6F9u11owY\nzwHAB9sOYgD/CjyrmeUxDTij+cwd3G5Yg+sfgW6WOZ1KaQl3NaX370JFOic6Sa8aZ3evjdUTlnE4\no/IZ4GOUehEXAO8D9gdeAhxLaQlXm2f2Fa+cBjzf9uymBsYPKPdG1WgS8xnA7c0ssP1sz2oOn0ql\n90X9OjVdWdJVtp/R93oNSh+/q4GdKi2XP5uH1hkbeG5TkGBN4EeVntN5lATqVBZOoHZ2na1crrO9\nyZIem6i6dj7Q2XZcvwJ2A1ajrDN+tu1rVardnuW+9ju1GLvmTtJzKJV79wButL19a8ENSAu2CBl7\nfrW2TfvNeC0zJAn4je2nthDWwPRQ4Z/xrGq7ukEB9fWcbl6vSEk+Hg1s2n+/VIsx36UvU3qWnkgp\nJnig7eqSJ0kPUB7kja2kLODVNdYpGfN7+r/+60HF17yrgO1t/0XSRZTWpPN6x2r7Pql0YNitySm2\npTywPLTpZlDl72is6i7aD+N2SVv2psI2I7ovpVwAqxx6tz1lEYfmUfr/1miK7SP7d9j+AzBd0v4t\nxTSsGyS9Fzi1V0RG0uMpifuNrUY2mK6dD3SzHZd7Bdwk3Wj72mbnDc2awurZvhi4WNJ/AFUWcqOM\nrPemHW4oaW3bd0qaRL1VsO+TtG3fk/+ebYF72whoSHdSigXeOvZAxdeH30nawU1rHdtzgf0lfRh4\nZbuhjcTTbO/RbH9N0gdajWZwVwBH2V5oarKk6pL2xqS+7aPHHKv1mnc4cIGkY4EfA2dK+gZlxtt3\n2gxsQJOae29sz1Jp0/dNSTVWKB9X15LcfYAH+nc003SmUp5edobte4Dr245jQF1MoF5DmYJ9oaT1\nmn23AedQ2hvUpmvnA91sx4WkFWzPB/br27ci9d5IHDXezuYcZy7bUEZm7Bq0u5t/1waqXO8J7Asc\n38wq6rXT2AD4a3OsNqcBTwYWSnKBM5ZxLKOyB+P08LR9mKQTWohnFDaQ9CnKKOdjJa1ku3ffV+s9\n7UGU7814an0YcZykNW3/zXZ/TYKnAt9rMa6B2T5T0qWU5QsbU/7GPofSo/m7rQY3mL9K2sj2b6EM\nNjWJ7teAqkalF6VT05WjDs0a40Mo04vGJlDTayzFDgtU9r7Y9t/69u9mu8anfAuQdJrtWvuUotJz\n8LWUysPfk7QXsD1lOcNnbd/faoADaKYYXWH73jH7pwDPs/2FNuKK5Uez1GT95uUtvZGBmJgkvbU/\n6aiNpH15aL2qgW/Y/nPzOXy77UPbjC+iFpK2BO62/Zsx+1cG9uzC/UOS3JhQJO1n++S241hSKlUr\n3wZcQ1ms/07bZzfHqlvb0EzB6d1I9OxMKa5g2y9rJbAhSDqdMoVqNWAOpSDGWcALAWxPbS+60ZG0\nju0/tR3HoFTaMvwnZVTwW7ZP7zt2nO23thbcgPofdDWF9z5B0+8cONgV9sldHElP702dr82YkcHe\nvsfa/mNbMQ2qmeI/1qHARwBsj51GGi2QdAzwVdsXtR3L0iTpB7Z3bjuOQUlah9K95RbKMshDeehB\n+UedNkITTpLcmFAk3WS7uvUAkq6kFC/qVfb+KnCa7RmVJrmXUi7cn6MUwxBlyt5rAXprvGoi6Qrb\nmzdTeX8PPNH23KZQzuW2N285xCUm6UjKWq47JG1Dqe44nzKNaqrtmW3GNwhJZwHXARdTqnHeD+xl\n+74av0uwUBGWE4E/UL5br6AUL9l9cT9fmxqv4800vdOAVYFLKOv3r2+O1fq5u4tSufvq3i7gnZSK\nqri0I6zKmETjJMoDsaoTDUl3ADcA6wJfokx/vbTdqIbT1CAY+6B8E8q13barq5Oj0mrwcmAtyhKU\nyynV8XcBtrD98hbDW2KS7qTcq54B/MAdTAhrXb8QFdPi+76tt5hjE5ls3wXgUlJ+B+CrKlVutfgf\nnZC2odwMvR94j+1LJd1XY3LbR82U5dUoN7JrAX8CVqHea+FLbL+v2T4KeI3tn0vahPKHq7rqysBG\ntnvr0L4m6f2UHp9V3UAsxjbAls0NxTHN9MvqSPr0Yg7X2Ev748CLKMnSq4DzJe1t+6fthjWUzShF\nf1YHptm+R9LUGpPbPl+gJBfbAG+gzIY4kpJonALUeJ242fY2zXX7tcAXmoexp1MS3uraIlFqxvyN\n0jLtHsp90I+Al1LnPRGUB+Mvbh6M32J7h2b/D5tKxbW5HfgV8CHgNJVq5WfY/lm7YY1OrTd2Ubd1\nKW1Pxnvi+pNlHMuodKqyd1MW/2hJZ1JuxG+n/uvFiZTp5CsCh1EqI14PbAf8b5uBDWFS3/TKVWz/\nHMD2dc26mhqt3FdMC9sfkXQLcCFlinmNHifpXZSbu7XGHKv1hm9f4N3A31mwuJEoPY5rs7Ltq5rt\nr0i6BjhL0vsW90MTme0bgVer9NP+XjMttnZjE40dm/21JhoPapLZDwIflPRM4HXAt4GNWg1sALZf\nJumVlKKvR9n+uqS5tm9oO7YhqKkpswawuqQNbV+v0ie3xkKP99g+Fji2GZB5LaVg2NqUZLf69e21\n37RGnc4F1hhvOo6kWkcKO1nZ2/bNwB5Nwv6XtuMZhu1jmqQd27dI+jxlPe5nxmmDUovjgG9JOgL4\njqRPUtYZ70x5QlujbwIvoPS/BMD2KZJuBRY3ejiRfQ5Ys9k+GXgscEdTVb7W39MvgCtt/3jsAUnT\nln04Q7tf0uN7LYRsX6XSvuVcKkwy+tk+W9L3KBXma22H1NO1RGNcti+j9D4/pO1YBuXSb/U84EMq\n7SFrffDacwTlQbmAfwM+W561sBmlvVC1mocPRwJHSno6pcNG9bImNyKiYs1awrdQWhqsSGnncjZw\n0tgCOrWQ9BxgfjP1+hmUmR/X2P5Wy6ENRNJ2lPj/Imk1yo3rVsBVwBG257Qa4ACaROM+l3Z21ZO0\nC3BHbzZO3/7JwIG2P9xOZNFP0usoa4oFvBV4c3NoM+Bw2//TVmyDUtNqp+04lqamku92tmttXQU8\n2J5PzSDGSsAzgd/b/n3LoS0xScfYPrjtOJamJLkRER1UcaXyaZSkdiXgPEofwgsoa+7OqzHZkHQ1\npTDJXEmfpfTJ/QplJsEWfWuQYwJJpfKJqUuJRk8z/Xobyu9qHnBdrRXKezp6Tk8G/mp7TlNk9NmU\nB5hXthpYjCtJbkREB9VY4RYerFS+JWVq223ABs0I6KrArEqrYF9je9Nm+5e2t+o7dpntZ7YX3WBU\n+pL+F6Wa938Bb6cUbLqG0kKtqn65i6lUvjKwTyqVT1yqv/fvDpS2YnMoxQJ/Qine9gCwt+3qpph3\n9JwOAd5E+R59nFKT4MeUuh4n2f5Ei+EtMUlHA2d1uXVV1uRGRFTqYSqVr7vMAhmtubbnAnMl/db2\nXwBs3ytpfsuxDeoqSfvbPgm4TNKz+6pg3992cAM6hbJ+eg1gJvBF4CWU6rYnUF+V21Qqr4AW0ftX\n0ipQbe/fTwK7NA9YNgSOsf3cZgr9icCu7YY3kC6e0z6UafGrA7OBDZvzWx2YRUnqa7I38HxJnWld\nNVaS3IiIenWxUvnfJa3WrPXsH/GcTJnyVqM3Ap+UdBhwB/ATSTdTigC9sdXIBreu7U8DSHqL7enN\n/k9LqvGcUqm8DoezcO/fFXiosFuNVrB9R7N9I/AUANvnN8UEa9TFc5rbPGy9n9IW6c8Atu+WVOO0\n2C62rlpAktyIiHp1sVL5DrbvA+jdnDdWBKa2E9JwmsJSU5s1khvSFAjrVfKt1Ap926ct5lgtUqm8\nDl3s/XuJpBMptQde1vxLM0JY43cJunlOl0o6g/LZ+wFwqqTvUK4RVy/2JyewLrWuGitrciMiImKJ\nSPoQ8LGxVWElbUypGP3qdiIbXFOp/M3AJnSkUnk/Sf8MbAtcYfu8tuMZhkrv3/cCx1A+hxu2HNLA\nmpkCBwCbUtoGnWR7XlOHYD3bs9uMbxAdPaeVgD0oa/W/QimK+HrgBuC/bd/dYnhLrEvr8hclSW5E\nRESMTN/646pI2hRYH7i4P3mXtJvt77QX2WAkzbK9bbN9APA24GuU9ZDftH1Em/ENS9IalN6/29p+\nfsvhRFRleWhdVeuUgYiIiJiYqps6KukdlFHbA4Erm5HCnlqTwZX6tt9EKQR0OCXJ3audkEbH9l22\n3117gitpsqTpkq6VdKekPzfb05taBJ0i6dttxzAISU+QdLyk/5a0jqRpkq6QdGZTbb421c5+eKSy\nJjciIiKWyMNU9l5vmQUyOv8ObG37rqb/5VckTbE9o92whjJJ0mMoxZkm9QoBNYVy5rYb2mCapO8Q\nYHfK58zA7ZQHFNOb9e+1ORP4PrAjcJttN0nT1OZYdZWIJW21qENArVNkT6FbFeUvlfQ7HqqsXO26\n4kXJdOWIiIhYIpJuYzGVvW0/cRmHNBRJV9l+Rt/rNYCvUgrK7GR7y9aCG5Ck2ZQkkObf59r+g6Q1\ngR9Vek7nURLCU1k4IdzZdo0J4XW2N1nSYxOZpHnADxdxeDvbqy7LeEahfw2rpBttP7nvWHX9ziVd\nSmkj9HpgT0rF6NOBL9W4Zno8GcmNiIiIJdW1yt63S9rS9q+gTIWV9FJKT88t2g1tMLanLOLQPOAV\nyzCUUZpi+8j+Hbb/AEyXtH9LMQ3rBknvBU61fRuApMdTEvcbW41scNcCbxqvDY2km1qIZxS6VlEe\n21cCh1J6TT+H0krooiaJ377d6IZX5S8lIiIi2mN7f9s/WsSx1y3reEZgH2CBlk5NReWpQNVrPsey\nfY/t69uOY0A3SHqvpAenxEt6vKT3UW9C+BrgscCFzZrcOynTYdehjLDVaBqLzjHesQzjGKVzmhke\n2H5/b6ekpwK/bi2qEbF9se2DgSdTEt/qZbpyREREREx4zRrjQyi9V3uJ7m3AOZQ1uX9uK7ZhdK2y\n93gkfd72Pm3HMShJj6KMdN5i+3uS9gK2pyxp+Kzt+1sNcAlJ2sv2F9uOY2lKkhsRERERVZO0n+2T\n245jSTWVvd8GXEMpyvRO22c3x6rsZSrpG5R14OrbvTPwA8C2X9ZKYEOQdDowCVgNmEMpQHUW8EIA\n21Pbi240JK1j+09txzEqWZMbEREREbX7IFBdksvClb2/2oHK3htQRjg/B8ynJLvbAEe1GdSQNre9\nuaQVgd8DT7Q9V9IXgMtbjm2JSZoOfML2HZK2oVTyni9pZWAf2zNbDXAEkuRGRERExITXwdZVUGZV\n3gVge7akHSiJ7lNYcCS0JtsA7wTeD7zH9qWS7rNdY1G6HjVTllcDVgXWAv4ErEKd+dRLbR/SbB8F\nvMb2zyVtApwBbN1eaKNR4y8lIiIiIpY/67KY1lXLOJZR6WJl73nA0ZLOBI6RdDv15xwnUqaUrwgc\nBpwp6XpgO+B/2wxsQJMkrdQU2FvF9s8BbF/XjOZWL2tyIyIiImLCk3QScPJ4lb0lnVFjZW9JTwIe\nsH3rmP2i9Da+qJ3IRqdJ2re3XXXVXknrA9i+RdLalPW4N9ie1W5kS07S2ykF3I6gVJBfm7LGeGfg\nH2zv3WJ4I5EkNyIiIiIiYjkiaSfgLcDGlBHqm4GzgZOaEd6qJcmNiIiIiIiIaiuVj5UkNyIiIiIi\nIpB0k+0ntR3HsGpfBB4RERERERGP0MNUKl93mQWyFCXJjYiIiIiIWH50sVL5ApLkRkRERERELD/O\nBdawfenYA5Jq7mf8oKzJjYiIiIiIiM5Yoe0AIiIiIiIiIkYlSW5ERERERER0RpLciIiIiIiI6Iwk\nuREREREREdEZSXIjIiIiIiKiM/4/KKc+ObLFTCgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f180249ce50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The probability that the distributions for payload/histograms/GECKO_THREAD_ACTIVITY_MS (absolute) are differing by chance is 0.00.\n"
+     ]
+    }
+   ],
+   "source": [
+    "compare_thread_activity(subset, \"Gecko\", 256)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Get top stacks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def get_stacks(subset):\n",
+    "    def yield_ping_stacks(ping):\n",
+    "        for thread in ping[\"payload\"][\"threadHangStats\"]:\n",
+    "            if thread[\"name\"] != \"Gecko\":\n",
+    "                continue\n",
+    "            for hang in thread[\"hangs\"]:\n",
+    "                if not hang[\"stack\"]:\n",
+    "                    continue\n",
+    "                values = hang[\"histogram\"][\"values\"]\n",
+    "                histogram = pd.Series(values.values(), index=map(int, values.keys())).sort_index()\n",
+    "                over_min_ms_count = histogram[histogram.index >= 255].sum()\n",
+    "                yield (tuple(hang[\"stack\"]), over_min_ms_count)\n",
+    "    return subset.flatMap(yield_ping_stacks).reduceByKey(lambda a, b: a + b).collectAsMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "we10s_stacks = get_stacks(subset.filter(lambda p: p[\"e10s\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ne10s_stacks = get_stacks(subset.filter(lambda p: not p[\"e10s\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def group_by_top_frame(stacks):\n",
+    "    total_hits = 0\n",
+    "    top_frames = {}\n",
+    "    for stack, hits in stacks.iteritems():\n",
+    "        stack_top_frame = stack[-1]\n",
+    "        if not stack_top_frame in top_frames:\n",
+    "            top_frames[stack_top_frame] = { \"frame\": stack_top_frame, \"stacks\": [], \"hits\": 0 }\n",
+    "\n",
+    "        top_frame = top_frames[stack_top_frame]\n",
+    "\n",
+    "        # Keep stacks sorted by hits.\n",
+    "        top_frame[\"stacks\"].append((stack, hits))\n",
+    "        top_frame[\"stacks\"].sort(key=lambda d: d[1], reverse=True)\n",
+    "\n",
+    "        top_frame[\"hits\"] += hits\n",
+    "        total_hits += hits\n",
+    "\n",
+    "    return top_frames, total_hits\n",
+    "\n",
+    "def get_stack_hits(stacks, stack):\n",
+    "    for s, h in stacks:\n",
+    "        if s == stack:\n",
+    "            return h\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "we10s_groups, we10s_total_hits = group_by_top_frame(we10s_stacks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ne10s_groups, ne10s_total_hits = group_by_top_frame(ne10s_stacks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Top stacks grouped by top frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "we10s_sorted_groups = sorted(we10s_groups.values(), key=lambda d: d[\"hits\"], reverse=True)\n",
+    "\n",
+    "def print_e10s_groups(group_count, stack_count):\n",
+    "    for we10s_group in we10s_sorted_groups[0:group_count]:\n",
+    "        ne10s_group = ne10s_groups.get(we10s_group[\"frame\"], {})\n",
+    "        ne10s_stacks = ne10s_group.get(\"stacks\", [])\n",
+    "        ne10s_hits = ne10s_group.get(\"hits\", 0)\n",
+    "\n",
+    "        print \"{:.2f}% ({:.2f}%): {} ({})\".format(\n",
+    "            100.0 * we10s_group[\"hits\"] / we10s_total_hits,\n",
+    "            100.0 * ne10s_hits / ne10s_total_hits,\n",
+    "            we10s_group[\"frame\"],\n",
+    "            we10s_group[\"hits\"])\n",
+    "        for we10s_stack, we10s_stack_hits in we10s_group[\"stacks\"][0:stack_count]:\n",
+    "            ne10s_stack_hits = get_stack_hits(ne10s_stacks, we10s_stack)\n",
+    "            print \"  - {:.4f}% ({:.4f}%):\".format(\n",
+    "                100.0 * we10s_stack_hits / we10s_total_hits,\n",
+    "                100.0 * ne10s_stack_hits / ne10s_total_hits)\n",
+    "            print \"    {}\\n\".format(\"\\n    \".join(reversed(we10s_stack)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Parent process top frames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The results are in the form: `e10s% (non-e10s%): top frame (total e10s hits)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "23.91% (4.59%): Startup::XRE_Main (625846)\n",
+      "14.06% (0.00%): IPDL::PJavaScript::SendGet (368110)\n",
+      "8.69% (0.73%): nsFilePicker::ShowFilePicker (227423)\n",
+      "3.44% (0.00%): IPDL::PJavaScript::SendCallOrConstruct (89992)\n",
+      "3.18% (0.87%): (chrome script) (83217)\n",
+      "2.92% (12.94%): js::GCRuntime::collect (76432)\n",
+      "2.47% (0.00%): IPDL::PJavaScript::SendGetPropertyDescriptor (64602)\n",
+      "2.08% (0.54%): self-hosted:649 (54321)\n",
+      "1.37% (5.21%): PresShell::DoReflow (35944)\n",
+      "1.30% (0.00%): IPDL::PPrinting::RecvShowPrintDialog (33992)\n",
+      "1.08% (0.47%): app/modules/WindowsJumpLists.jsm:316 (28261)\n",
+      "1.03% (0.13%): app/modules/WindowsJumpLists.jsm:270 (26971)\n",
+      "0.92% (0.24%): nsInputStreamPump::OnStateStop (24166)\n",
+      "0.91% (0.36%): gre/modules/TelemetryController.jsm:282 (23717)\n",
+      "0.85% (0.00%): CPOWProxyHandler::get (22142)\n",
+      "0.84% (0.14%): nsXREDirProvider::DoShutdown (22086)\n",
+      "0.74% (3.77%): IPDL::PLayerTransaction::SendUpdate (19418)\n",
+      "0.73% (0.18%): browser/content/browser.xul:1 (19004)\n",
+      "0.71% (0.24%): mozilla::ipc::GeckoChildProcessHost::WaitUntilConnected (18642)\n",
+      "0.65% (0.16%): mozilla::scache::StartupCache::GetBuffer (17098)\n",
+      "0.65% (0.97%): PresShell::Flush (16896)\n",
+      "0.62% (0.11%): xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get (16181)\n",
+      "0.58% (0.52%): Timer::Fire (15305)\n",
+      "0.58% (0.65%): DisplayList::Draw (15124)\n",
+      "0.57% (0.14%): Statement::ExecuteStep (14907)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_e10s_groups(25, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Parent process top stacks for top frames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "23.91% (4.59%): Startup::XRE_Main (625846)\n",
+      "  - 23.9088% (4.5939%):\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "14.06% (0.00%): IPDL::PJavaScript::SendGet (368110)\n",
+      "  - 1.8640% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendGet\n",
+      "    CPOWProxyHandler::get\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    idmhelper5.js:99\n",
+      "    idmhelper8.js:45\n",
+      "    IPDL::PContent::RecvRpcMessage\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 1.5338% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendGet\n",
+      "    CPOWProxyHandler::get\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    saff/content/annotationEngine.js:152\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 1.0090% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendGet\n",
+      "    CPOWProxyHandler::get\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    saff/content/annotationEngine.js:148\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "8.69% (0.73%): nsFilePicker::ShowFilePicker (227423)\n",
+      "  - 8.2615% (0.6796%):\n",
+      "    nsFilePicker::ShowFilePicker\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.2646% (0.0428%):\n",
+      "    nsFilePicker::ShowFilePicker\n",
+      "    gre/components/nsHelperAppDlg.js:311\n",
+      "    gre/modules/DownloadLastDir.jsm:162\n",
+      "    gre/modules/ContentPrefUtils.jsm:36\n",
+      "    gre/modules/ContentPrefService2.jsm:146\n",
+      "    gre/modules/ContentPrefService2.jsm:738\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1109% (0.0001%):\n",
+      "    nsFilePicker::ShowFilePicker\n",
+      "    global/content/bindings/dialog.xml:335\n",
+      "    EventDispatcher::Dispatch\n",
+      "    nsViewManager::DispatchEvent\n",
+      "    nsXULWindow::ShowModal\n",
+      "    gre/components/nsHelperAppDlg.js:781\n",
+      "    mozapps/content/downloads/unknownContentType.xul:1\n",
+      "    EventDispatcher::Dispatch\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "3.44% (0.00%): IPDL::PJavaScript::SendCallOrConstruct (89992)\n",
+      "  - 0.5265% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendCallOrConstruct\n",
+      "    CPOWProxyHandler::call\n",
+      "    saff/content/annotationEngine.js:152\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.3247% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendCallOrConstruct\n",
+      "    CPOWProxyHandler::call\n",
+      "    saff/content/annotationEngine.js:148\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.3018% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendCallOrConstruct\n",
+      "    CPOWProxyHandler::call\n",
+      "    CPOWDOMQI\n",
+      "    idmhelper5.js:91\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "3.18% (0.87%): (chrome script) (83217)\n",
+      "  - 1.2491% (0.3216%):\n",
+      "    (chrome script)\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.2236% (0.0602%):\n",
+      "    (chrome script)\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1203% (0.0332%):\n",
+      "    (chrome script)\n",
+      "    self-hosted:749\n",
+      "    self-hosted:649\n",
+      "    gre/modules/Task.jsm:308\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "2.92% (12.94%): js::GCRuntime::collect (76432)\n",
+      "  - 1.1379% (6.0937%):\n",
+      "    js::GCRuntime::collect\n",
+      "    nsJSContext::GarbageCollectNow\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.6286% (4.8404%):\n",
+      "    js::GCRuntime::collect\n",
+      "    nsRefreshDriver::Tick\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.4836% (0.2068%):\n",
+      "    js::GCRuntime::collect\n",
+      "    nsXREDirProvider::DoShutdown\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "2.47% (0.00%): IPDL::PJavaScript::SendGetPropertyDescriptor (64602)\n",
+      "  - 1.3157% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendGetPropertyDescriptor\n",
+      "    CPOWProxyHandler::getPropertyDescriptor\n",
+      "    CPOWDOMQI\n",
+      "    idmhelper5.js:91\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1329% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendGetPropertyDescriptor\n",
+      "    CPOWProxyHandler::getPropertyDescriptor\n",
+      "    CPOWDOMQI\n",
+      "    idmhelper5.js:130\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1300% (0.0000%):\n",
+      "    IPDL::PJavaScript::SendGetPropertyDescriptor\n",
+      "    CPOWProxyHandler::getPropertyDescriptor\n",
+      "    CPOWDOMQI\n",
+      "    mozilla_cc2@internetdownloadmanager.com/components/idmhelper5.js:91\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "2.08% (0.54%): self-hosted:649 (54321)\n",
+      "  - 1.6307% (0.4147%):\n",
+      "    self-hosted:649\n",
+      "    gre/modules/Task.jsm:308\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1059% (0.0296%):\n",
+      "    self-hosted:649\n",
+      "    gre/modules/Task.jsm:226\n",
+      "    gre/components/nsBlocklistService.js:621\n",
+      "    EventDispatcher::Dispatch\n",
+      "    nsXMLHttpRequest::OnStopRequest\n",
+      "    nsHttpChannel::OnStopRequest\n",
+      "    nsInputStreamPump::OnStateStop\n",
+      "    nsInputStreamPump::OnInputStreamReady\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0716% (0.0068%):\n",
+      "    self-hosted:649\n",
+      "    gre/modules/Task.jsm:308\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Events::ProcessGeckoEvents\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "1.37% (5.21%): PresShell::DoReflow (35944)\n",
+      "  - 0.4898% (1.2492%):\n",
+      "    PresShell::DoReflow\n",
+      "    PresShell::Flush\n",
+      "    nsRefreshDriver::Tick\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.2618% (0.1023%):\n",
+      "    PresShell::DoReflow\n",
+      "    PresShell::Flush\n",
+      "    browser/content/newtab/newTab.js:714\n",
+      "    browser/content/newtab/newTab.js:419\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1344% (0.0000%):\n",
+      "    PresShell::DoReflow\n",
+      "    PresShell::Flush\n",
+      "    browser/content/browser.xul:1\n",
+      "    EventDispatcher::Dispatch\n",
+      "    browser/content/tabbrowser.xml:4022\n",
+      "    IPDL::PBrowser::RecvRpcMessage\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "1.30% (0.00%): IPDL::PPrinting::RecvShowPrintDialog (33992)\n",
+      "  - 1.2933% (0.0000%):\n",
+      "    IPDL::PPrinting::RecvShowPrintDialog\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0039% (0.0000%):\n",
+      "    IPDL::PPrinting::RecvShowPrintDialog\n",
+      "    Events::ProcessGeckoEvents\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0005% (0.0000%):\n",
+      "    IPDL::PPrinting::RecvShowPrintDialog\n",
+      "    nsXULWindow::ShowModal\n",
+      "    _e1members_/content/mindspark/homepageSpecific.js:134\n",
+      "    _e1members_/content/mindspark/core.js:300\n",
+      "    _e1members_/content/search/protection.js:61\n",
+      "    _e1members_/content/mindspark/core.js:255\n",
+      "    _e1members_/content/mindspark/homepageSpecific.js:446\n",
+      "    gre/modules/AddonManager.jsm:177\n",
+      "    gre/modules/AddonManager.jsm:194\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "1.08% (0.47%): app/modules/WindowsJumpLists.jsm:316 (28261)\n",
+      "  - 1.0647% (0.4674%):\n",
+      "    app/modules/WindowsJumpLists.jsm:316\n",
+      "    app/modules/WindowsJumpLists.jsm:446\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0033% (0.0012%):\n",
+      "    app/modules/WindowsJumpLists.jsm:316\n",
+      "    app/modules/WindowsJumpLists.jsm:446\n",
+      "    nsFilePicker::ShowFilePicker\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0020% (0.0007%):\n",
+      "    app/modules/WindowsJumpLists.jsm:316\n",
+      "    app/modules/WindowsJumpLists.jsm:432\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "1.03% (0.13%): app/modules/WindowsJumpLists.jsm:270 (26971)\n",
+      "  - 1.0241% (0.1305%):\n",
+      "    app/modules/WindowsJumpLists.jsm:270\n",
+      "    app/modules/WindowsJumpLists.jsm:316\n",
+      "    app/modules/WindowsJumpLists.jsm:446\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0021% (0.0001%):\n",
+      "    app/modules/WindowsJumpLists.jsm:270\n",
+      "    app/modules/WindowsJumpLists.jsm:316\n",
+      "    app/modules/WindowsJumpLists.jsm:446\n",
+      "    nsFilePicker::ShowFilePicker\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0012% (0.0003%):\n",
+      "    app/modules/WindowsJumpLists.jsm:270\n",
+      "    app/modules/WindowsJumpLists.jsm:316\n",
+      "    app/modules/WindowsJumpLists.jsm:446\n",
+      "    services-common/async.js:156\n",
+      "    gre/modules/services-sync/service.js:978\n",
+      "    services-sync/util.js:146\n",
+      "    services-sync/util.js:98\n",
+      "    services-sync/util.js:76\n",
+      "    gre/modules/services-sync/service.js:1279\n",
+      "    services-sync/util.js:76\n",
+      "    gre/modules/services-sync/service.js:1271\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.92% (0.24%): nsInputStreamPump::OnStateStop (24166)\n",
+      "  - 0.8458% (0.2221%):\n",
+      "    nsInputStreamPump::OnStateStop\n",
+      "    nsInputStreamPump::OnInputStreamReady\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0333% (0.0091%):\n",
+      "    nsInputStreamPump::OnStateStop\n",
+      "    nsInputStreamPump::OnInputStreamReady\n",
+      "    self-hosted:749\n",
+      "    self-hosted:649\n",
+      "    gre/modules/Task.jsm:308\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0201% (0.0000%):\n",
+      "    nsInputStreamPump::OnStateStop\n",
+      "    nsInputStreamPump::OnInputStreamReady\n",
+      "    IPDL::PContent::RecvCreateWindow\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.91% (0.36%): gre/modules/TelemetryController.jsm:282 (23717)\n",
+      "  - 0.7453% (0.3065%):\n",
+      "    gre/modules/TelemetryController.jsm:282\n",
+      "    gre/modules/TelemetrySession.jsm:334\n",
+      "    gre/modules/Timer.jsm:29\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0439% (0.0161%):\n",
+      "    gre/modules/TelemetryController.jsm:282\n",
+      "    gre/modules/TelemetrySession.jsm:384\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0358% (0.0115%):\n",
+      "    gre/modules/TelemetryController.jsm:282\n",
+      "    self-hosted:649\n",
+      "    gre/modules/Task.jsm:308\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.85% (0.00%): CPOWProxyHandler::get (22142)\n",
+      "  - 0.1976% (0.0000%):\n",
+      "    CPOWProxyHandler::get\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    saff/content/annotationEngine.js:152\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1340% (0.0000%):\n",
+      "    CPOWProxyHandler::get\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    saff/content/annotationEngine.js:148\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0844% (0.0000%):\n",
+      "    CPOWProxyHandler::get\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    idmhelper5.js:99\n",
+      "    idmhelper8.js:45\n",
+      "    IPDL::PContent::RecvRpcMessage\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.84% (0.14%): nsXREDirProvider::DoShutdown (22086)\n",
+      "  - 0.8437% (0.1359%):\n",
+      "    nsXREDirProvider::DoShutdown\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0000% (0.0000%):\n",
+      "    nsXREDirProvider::DoShutdown\n",
+      "    nsViewManager::DispatchEvent\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.74% (3.77%): IPDL::PLayerTransaction::SendUpdate (19418)\n",
+      "  - 0.5811% (2.8309%):\n",
+      "    IPDL::PLayerTransaction::SendUpdate\n",
+      "    ShadowLayerForwarder::EndTransaction\n",
+      "    nsDisplayList::PaintRoot\n",
+      "    nsLayoutUtils::PaintFrame\n",
+      "    PresShell::Paint\n",
+      "    nsRefreshDriver::Tick\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1173% (0.6860%):\n",
+      "    IPDL::PLayerTransaction::SendUpdate\n",
+      "    ShadowLayerForwarder::EndTransaction\n",
+      "    nsDisplayList::PaintRoot\n",
+      "    nsLayoutUtils::PaintFrame\n",
+      "    PresShell::Paint\n",
+      "    nsRefreshDriver::Tick\n",
+      "    IPDL::PCompositor::RecvDidComposite\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0321% (0.0197%):\n",
+      "    IPDL::PLayerTransaction::SendUpdate\n",
+      "    ShadowLayerForwarder::EndTransaction\n",
+      "    nsDisplayList::PaintRoot\n",
+      "    nsLayoutUtils::PaintFrame\n",
+      "    PresShell::Paint\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.73% (0.18%): browser/content/browser.xul:1 (19004)\n",
+      "  - 0.4742% (0.1227%):\n",
+      "    browser/content/browser.xul:1\n",
+      "    EventDispatcher::Dispatch\n",
+      "    nsViewManager::DispatchEvent\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.1243% (0.0273%):\n",
+      "    browser/content/browser.xul:1\n",
+      "    EventDispatcher::Dispatch\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0273% (0.0000%):\n",
+      "    browser/content/browser.xul:1\n",
+      "    EventDispatcher::Dispatch\n",
+      "    browser/content/tabbrowser.xml:4022\n",
+      "    IPDL::PBrowser::RecvRpcMessage\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.71% (0.24%): mozilla::ipc::GeckoChildProcessHost::WaitUntilConnected (18642)\n",
+      "  - 0.6923% (0.0000%):\n",
+      "    mozilla::ipc::GeckoChildProcessHost::WaitUntilConnected\n",
+      "    GetNewPluginLibrary\n",
+      "    nsNPAPIPlugin::CreatePlugin\n",
+      "    nsPluginHost::GetPluginForContentProcess\n",
+      "    mozilla::plugins::SetupBridge\n",
+      "    IPDL::PContent::RecvLoadPlugin\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0080% (0.0022%):\n",
+      "    mozilla::ipc::GeckoChildProcessHost::WaitUntilConnected\n",
+      "    GetNewPluginLibrary\n",
+      "    nsNPAPIPlugin::CreatePlugin\n",
+      "    browser/content/sanitize.js:295\n",
+      "    gre/modules/Promise-backend.js:335\n",
+      "    self-hosted:666\n",
+      "    gre/modules/Task.jsm:308\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0012% (0.0004%):\n",
+      "    mozilla::ipc::GeckoChildProcessHost::WaitUntilConnected\n",
+      "    GetNewPluginLibrary\n",
+      "    nsNPAPIPlugin::CreatePlugin\n",
+      "    (chrome script)\n",
+      "    self-hosted:666\n",
+      "    gre/modules/Task.jsm:308\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.65% (0.16%): mozilla::scache::StartupCache::GetBuffer (17098)\n",
+      "  - 0.0333% (0.0000%):\n",
+      "    mozilla::scache::StartupCache::GetBuffer\n",
+      "    mozilla::dom::ContentParent::CreateBrowserOrApp\n",
+      "    nsFrameLoader::CreateRemoteBrowser\n",
+      "    nsFrameLoader::ShowRemoteFrame\n",
+      "    mozilla::AsyncFrameInit::Run\n",
+      "    browser/content/tabbrowser.xml:1574\n",
+      "    /modules/sessionstore/SessionStore.jsm:3161\n",
+      "    /modules/sessionstore/SessionStore.jsm:2514\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0241% (0.0000%):\n",
+      "    mozilla::scache::StartupCache::GetBuffer\n",
+      "    (chrome script)\n",
+      "    global/content/bindings/browser.xml:843\n",
+      "    browser/content/tabbrowser.xml:1574\n",
+      "    /modules/sessionstore/SessionStore.jsm:3161\n",
+      "    /modules/sessionstore/SessionStore.jsm:2514\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0212% (0.0000%):\n",
+      "    mozilla::scache::StartupCache::GetBuffer\n",
+      "    global/content/bindings/remote-browser.xml:337\n",
+      "    browser/content/tabbrowser.xml:1574\n",
+      "    /modules/sessionstore/SessionStore.jsm:3161\n",
+      "    /modules/sessionstore/SessionStore.jsm:2514\n",
+      "    gre/modules/Promise-backend.js:792\n",
+      "    gre/modules/Promise-backend.js:746\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.65% (0.97%): PresShell::Flush (16896)\n",
+      "  - 0.4383% (0.0690%):\n",
+      "    PresShell::Flush\n",
+      "    browser/content/newtab/newTab.js:714\n",
+      "    browser/content/newtab/newTab.js:419\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0384% (0.1411%):\n",
+      "    PresShell::Flush\n",
+      "    nsRefreshDriver::Tick\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0314% (0.0020%):\n",
+      "    PresShell::Flush\n",
+      "    browser/content/newtab/newTab.js:419\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.62% (0.11%): xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get (16181)\n",
+      "  - 0.1354% (0.0000%):\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    idmhelper5.js:99\n",
+      "    idmhelper8.js:45\n",
+      "    IPDL::PContent::RecvRpcMessage\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0981% (0.0000%):\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    saff/content/annotationEngine.js:152\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0651% (0.0000%):\n",
+      "    xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "    saff/content/annotationEngine.js:148\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.58% (0.52%): Timer::Fire (15305)\n",
+      "  - 0.4958% (0.4925%):\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0628% (0.0147%):\n",
+      "    Timer::Fire\n",
+      "    Events::ProcessGeckoEvents\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0074% (0.0014%):\n",
+      "    Timer::Fire\n",
+      "    nsXREDirProvider::DoShutdown\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.58% (0.65%): DisplayList::Draw (15124)\n",
+      "  - 0.3544% (0.3822%):\n",
+      "    DisplayList::Draw\n",
+      "    FrameLayerBuilder::DrawPaintedLayer\n",
+      "    ClientPaintedLayer::PaintThebes\n",
+      "    ClientLayerManager::EndTransactionInternal\n",
+      "    nsDisplayList::PaintRoot\n",
+      "    nsLayoutUtils::PaintFrame\n",
+      "    PresShell::Paint\n",
+      "    nsRefreshDriver::Tick\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0701% (0.0233%):\n",
+      "    DisplayList::Draw\n",
+      "    FrameLayerBuilder::DrawPaintedLayer\n",
+      "    ClientPaintedLayer::PaintThebes\n",
+      "    ClientLayerManager::EndTransactionInternal\n",
+      "    nsDisplayList::PaintRoot\n",
+      "    nsLayoutUtils::PaintFrame\n",
+      "    PresShell::Paint\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0349% (0.0112%):\n",
+      "    DisplayList::Draw\n",
+      "    FrameLayerBuilder::DrawPaintedLayer\n",
+      "    BasicPaintedLayer::PaintThebes\n",
+      "    BasicLayerManager::PaintLayer\n",
+      "    BasicLayerManager::EndTransactionInternal\n",
+      "    nsDisplayList::PaintRoot\n",
+      "    nsLayoutUtils::PaintFrame\n",
+      "    gfxUtils::DrawPixelSnapped\n",
+      "    layout::nsLayoutUtils::DrawBackgroundImage\n",
+      "    nsCSSRendering::PaintBackground\n",
+      "    DisplayList::Draw\n",
+      "    FrameLayerBuilder::DrawPaintedLayer\n",
+      "    ClientPaintedLayer::PaintThebes\n",
+      "    ClientLayerManager::EndTransactionInternal\n",
+      "    nsDisplayList::PaintRoot\n",
+      "    nsLayoutUtils::PaintFrame\n",
+      "    PresShell::Paint\n",
+      "    nsRefreshDriver::Tick\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "0.57% (0.14%): Statement::ExecuteStep (14907)\n",
+      "  - 0.1398% (0.0416%):\n",
+      "    Statement::ExecuteStep\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0533% (0.0109%):\n",
+      "    Statement::ExecuteStep\n",
+      "    nsHttpChannel::OnDataAvailable\n",
+      "    nsInputStreamPump::OnStateTransfer\n",
+      "    nsInputStreamPump::OnInputStreamReady\n",
+      "    Startup::XRE_Main\n",
+      "\n",
+      "  - 0.0440% (0.0038%):\n",
+      "    Statement::ExecuteStep\n",
+      "    forecastfox/content/locations.js:322\n",
+      "    Timer::Fire\n",
+      "    Startup::XRE_Main\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_e10s_groups(25, 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Top stacks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def print_top_stacks(a_stacks, b_stacks, count):\n",
+    "    from collections import Counter\n",
+    "    a_total_count = sum(a_stacks.values())\n",
+    "    b_total_count = sum(b_stacks.values())\n",
+    "    for a_stack, a_stack_count in Counter(a_stacks).most_common(count):\n",
+    "        b_stack_count = b_stacks.get(a_stack, 0)\n",
+    "        print \"- {:.4f}% ({:.4f}%):\".format(\n",
+    "            100.0 * a_stack_count / a_total_count,\n",
+    "            100.0 * b_stack_count / b_total_count)\n",
+    "        print \"  {}\\n\".format(\"\\n  \".join(reversed(a_stack)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### e10s parent process stacks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- 23.9088% (4.5939%):\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 8.2615% (0.6796%):\n",
+      "  nsFilePicker::ShowFilePicker\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.8640% (0.0000%):\n",
+      "  IPDL::PJavaScript::SendGet\n",
+      "  CPOWProxyHandler::get\n",
+      "  xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "  idmhelper5.js:99\n",
+      "  idmhelper8.js:45\n",
+      "  IPDL::PContent::RecvRpcMessage\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.6307% (0.4147%):\n",
+      "  self-hosted:649\n",
+      "  gre/modules/Task.jsm:308\n",
+      "  gre/modules/Promise-backend.js:792\n",
+      "  gre/modules/Promise-backend.js:746\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.5338% (0.0000%):\n",
+      "  IPDL::PJavaScript::SendGet\n",
+      "  CPOWProxyHandler::get\n",
+      "  xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "  saff/content/annotationEngine.js:152\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.3157% (0.0000%):\n",
+      "  IPDL::PJavaScript::SendGetPropertyDescriptor\n",
+      "  CPOWProxyHandler::getPropertyDescriptor\n",
+      "  CPOWDOMQI\n",
+      "  idmhelper5.js:91\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.2933% (0.0000%):\n",
+      "  IPDL::PPrinting::RecvShowPrintDialog\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.2491% (0.3216%):\n",
+      "  (chrome script)\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.1379% (6.0937%):\n",
+      "  js::GCRuntime::collect\n",
+      "  nsJSContext::GarbageCollectNow\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.0647% (0.4674%):\n",
+      "  app/modules/WindowsJumpLists.jsm:316\n",
+      "  app/modules/WindowsJumpLists.jsm:446\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.0241% (0.1305%):\n",
+      "  app/modules/WindowsJumpLists.jsm:270\n",
+      "  app/modules/WindowsJumpLists.jsm:316\n",
+      "  app/modules/WindowsJumpLists.jsm:446\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.0090% (0.0000%):\n",
+      "  IPDL::PJavaScript::SendGet\n",
+      "  CPOWProxyHandler::get\n",
+      "  xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "  saff/content/annotationEngine.js:148\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.8458% (0.2221%):\n",
+      "  nsInputStreamPump::OnStateStop\n",
+      "  nsInputStreamPump::OnInputStreamReady\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.8437% (0.1359%):\n",
+      "  nsXREDirProvider::DoShutdown\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.7453% (0.3065%):\n",
+      "  gre/modules/TelemetryController.jsm:282\n",
+      "  gre/modules/TelemetrySession.jsm:334\n",
+      "  gre/modules/Timer.jsm:29\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.7319% (0.0000%):\n",
+      "  IPDL::PJavaScript::SendGet\n",
+      "  CPOWProxyHandler::get\n",
+      "  global/content/bindings/remote-browser.xml:164\n",
+      "  gre/modules/RemoteAddonsParent.jsm:868\n",
+      "  gre/components/multiprocessShims.js:165\n",
+      "  xpc::AddonWrapper<class js::CrossCompartmentWrapper>::get\n",
+      "  lvd-sae/js/modules/contentscript.js:22\n",
+      "  gre/modules/Timer.jsm:29\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6923% (0.0000%):\n",
+      "  mozilla::ipc::GeckoChildProcessHost::WaitUntilConnected\n",
+      "  GetNewPluginLibrary\n",
+      "  nsNPAPIPlugin::CreatePlugin\n",
+      "  nsPluginHost::GetPluginForContentProcess\n",
+      "  mozilla::plugins::SetupBridge\n",
+      "  IPDL::PContent::RecvLoadPlugin\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6286% (4.8404%):\n",
+      "  js::GCRuntime::collect\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.5811% (2.8309%):\n",
+      "  IPDL::PLayerTransaction::SendUpdate\n",
+      "  ShadowLayerForwarder::EndTransaction\n",
+      "  nsDisplayList::PaintRoot\n",
+      "  nsLayoutUtils::PaintFrame\n",
+      "  PresShell::Paint\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.5265% (0.0000%):\n",
+      "  IPDL::PJavaScript::SendCallOrConstruct\n",
+      "  CPOWProxyHandler::call\n",
+      "  saff/content/annotationEngine.js:152\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.4958% (0.4925%):\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.4898% (1.2492%):\n",
+      "  PresShell::DoReflow\n",
+      "  PresShell::Flush\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.4836% (0.2068%):\n",
+      "  js::GCRuntime::collect\n",
+      "  nsXREDirProvider::DoShutdown\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.4742% (0.1227%):\n",
+      "  browser/content/browser.xul:1\n",
+      "  EventDispatcher::Dispatch\n",
+      "  nsViewManager::DispatchEvent\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.4578% (0.1175%):\n",
+      "  app/modules/WindowsJumpLists.jsm:545\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_top_stacks(we10s_stacks, ne10s_stacks, 25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### non-e10s parent process stacks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- 8.9379% (0.1834%):\n",
+      "  (content script)\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 6.0937% (1.1379%):\n",
+      "  js::GCRuntime::collect\n",
+      "  nsJSContext::GarbageCollectNow\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 5.8339% (0.0535%):\n",
+      "  (content script)\n",
+      "  EventDispatcher::Dispatch\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 4.8404% (0.6286%):\n",
+      "  js::GCRuntime::collect\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 4.5939% (23.9088%):\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 2.8309% (0.5811%):\n",
+      "  IPDL::PLayerTransaction::SendUpdate\n",
+      "  ShadowLayerForwarder::EndTransaction\n",
+      "  nsDisplayList::PaintRoot\n",
+      "  nsLayoutUtils::PaintFrame\n",
+      "  PresShell::Paint\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 2.6305% (0.0073%):\n",
+      "  (content script)\n",
+      "  EventDispatcher::Dispatch\n",
+      "  nsXMLHttpRequest::OnStopRequest\n",
+      "  nsHttpChannel::OnStopRequest\n",
+      "  nsInputStreamPump::OnStateStop\n",
+      "  nsInputStreamPump::OnInputStreamReady\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 2.4982% (0.0010%):\n",
+      "  (content script)\n",
+      "  EventDispatcher::Dispatch\n",
+      "  nsViewManager::DispatchEvent\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 2.2986% (0.0000%):\n",
+      "  IPDL::PPluginInstance::SendNPP_NewStream\n",
+      "  PluginModuleParent::NPP_NewStream\n",
+      "  nsNPAPIPluginStreamListener::OnStartBinding\n",
+      "  nsPluginStreamListenerPeer::OnStartRequest\n",
+      "  nsHttpChannel::OnStartRequest\n",
+      "  nsInputStreamPump::OnStateStart\n",
+      "  nsInputStreamPump::OnInputStreamReady\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 2.0813% (0.0517%):\n",
+      "  (content script)\n",
+      "  nsJSUtils::EvaluateString\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.7591% (0.0546%):\n",
+      "  (content script)\n",
+      "  nsJSUtils::EvaluateString\n",
+      "  nsHtml5TreeOpExecutor::RunFlushLoop\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.5837% (0.2283%):\n",
+      "  nsCycleCollector::collectSlice\n",
+      "  nsJSContext::RunCycleCollectorSlice\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.2492% (0.4898%):\n",
+      "  PresShell::DoReflow\n",
+      "  PresShell::Flush\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.0963% (0.0325%):\n",
+      "  nsDisplayBoxShadowOuter::Paint\n",
+      "  DisplayList::Draw\n",
+      "  FrameLayerBuilder::DrawPaintedLayer\n",
+      "  ClientPaintedLayer::PaintThebes\n",
+      "  ClientLayerManager::EndTransactionInternal\n",
+      "  nsDisplayList::PaintRoot\n",
+      "  nsLayoutUtils::PaintFrame\n",
+      "  PresShell::Paint\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 1.0024% (0.0008%):\n",
+      "  PresShell::DoReflow\n",
+      "  PresShell::Flush\n",
+      "  (content script)\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.8706% (0.0000%):\n",
+      "  IPDL::PPluginInstance::SendNPP_HandleEvent\n",
+      "  nsNPAPIPluginInstance::HandleEvent\n",
+      "  EventDispatcher::Dispatch\n",
+      "  nsViewManager::DispatchEvent\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.8701% (0.0001%):\n",
+      "  nsStyleSet::FileRules\n",
+      "  (content script)\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6860% (0.1173%):\n",
+      "  IPDL::PLayerTransaction::SendUpdate\n",
+      "  ShadowLayerForwarder::EndTransaction\n",
+      "  nsDisplayList::PaintRoot\n",
+      "  nsLayoutUtils::PaintFrame\n",
+      "  PresShell::Paint\n",
+      "  nsRefreshDriver::Tick\n",
+      "  IPDL::PCompositor::RecvDidComposite\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6796% (8.2615%):\n",
+      "  nsFilePicker::ShowFilePicker\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6642% (0.0000%):\n",
+      "  IPDL::PPluginInstance::SendNPP_Destroy\n",
+      "  nsPluginHost::StopPluginInstance\n",
+      "  nsObjectLoadingContent::StopPluginInstance\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6318% (0.0000%):\n",
+      "  IPDL::PPluginScriptableObject::SendHasProperty\n",
+      "  NPObjWrapper_Resolve\n",
+      "  (content script)\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6217% (0.0000%):\n",
+      "  IPDL::PPluginScriptableObject::SendHasMethod\n",
+      "  NPObjWrapper_Resolve\n",
+      "  (content script)\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6189% (0.2813%):\n",
+      "  nsCycleCollector::forgetSkippable\n",
+      "  Timer::Fire\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.6155% (0.2852%):\n",
+      "  ClientPaintedLayer::PaintThebes\n",
+      "  ClientLayerManager::EndTransactionInternal\n",
+      "  nsDisplayList::PaintRoot\n",
+      "  nsLayoutUtils::PaintFrame\n",
+      "  PresShell::Paint\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n",
+      "- 0.5785% (0.0343%):\n",
+      "  nsDisplayText::Paint\n",
+      "  DisplayList::Draw\n",
+      "  FrameLayerBuilder::DrawPaintedLayer\n",
+      "  ClientPaintedLayer::PaintThebes\n",
+      "  ClientLayerManager::EndTransactionInternal\n",
+      "  nsDisplayList::PaintRoot\n",
+      "  nsLayoutUtils::PaintFrame\n",
+      "  PresShell::Paint\n",
+      "  nsRefreshDriver::Tick\n",
+      "  Startup::XRE_Main\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_top_stacks(ne10s_stacks, we10s_stacks, 25)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/beta45-withaddons/top_addons.ipynb
+++ b/beta45-withaddons/top_addons.ipynb
@@ -1,0 +1,565 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### e10s-beta45-withaddons: Top addons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Bug 1224518](https://bugzilla.mozilla.org/show_bug.cgi?id=1224518)\n",
+    "\n",
+    "This analysis lists the top addons in the Telemetry pings and compares them to the [whitelisted e10s addon list](https://wiki.mozilla.org/Electrolysis/Addons)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unable to parse whitelist (/home/hadoop/anaconda2/lib/python2.7/site-packages/moztelemetry/bucket-whitelist.json). Assuming all histograms are acceptable.\n",
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ujson as json\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.plotly as py\n",
+    "import IPython\n",
+    "\n",
+    "from __future__ import division\n",
+    "from moztelemetry.spark import get_pings, get_one_ping_per_client, get_pings_properties\n",
+    "from montecarlino import grouped_permutation_test\n",
+    "\n",
+    "from whitelist import ADDON_WHITELIST\n",
+    "\n",
+    "%pylab inline\n",
+    "IPython.core.pylabtools.figsize(16, 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "160"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.defaultParallelism"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Get addons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dataset = sqlContext.read.load(\"s3://telemetry-parquet/e10s-experiment/e10s-beta45-withaddons@experiments.mozilla.org/generationDate=20160207\", \"parquet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Transform Dataframe to RDD of pings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def row_2_ping(row):\n",
+    "    ping = {\"environment\": {\"addons\": json.loads(row.addons)}}\n",
+    "    return ping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "subset = dataset.rdd.map(row_2_ping)\n",
+    "subset_count = subset.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "959609"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subset_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def ping_has_addons(ping, check_id_func):\n",
+    "    activeAddons = ping[\"environment\"][\"addons\"].get(\"activeAddons\", {})\n",
+    "    if not activeAddons:\n",
+    "        return False\n",
+    "    for k, v in activeAddons.iteritems():\n",
+    "        if not check_id_func(k):\n",
+    "            return False\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many clients had at least one addon?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "any_subset = subset.filter(lambda p: ping_has_addons(p, lambda k: True))\n",
+    "any_subset_count = any_subset.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "99.29%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"{:.2f}%\".format(100.0 * any_subset_count / subset_count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many clients had only whitelisted addons?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "whitelisted_subset = subset.filter(lambda p: ping_has_addons(p, lambda k: k in ADDON_WHITELIST))\n",
+    "whitelisted_subset_count = whitelisted_subset.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.04%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"{:.2f}%\".format(100.0 * whitelisted_subset_count / subset_count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many clients had at least one unwhitelisted addon?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "99.25%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"{:.2f}%\".format(100.0 * (any_subset_count - whitelisted_subset_count) / subset_count)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_ping_addons(ping):\n",
+    "    activeAddons = ping[\"environment\"][\"addons\"].get(\"activeAddons\", {})\n",
+    "    for k, v in activeAddons.iteritems():\n",
+    "        if v.get(\"name\"):\n",
+    "            yield (k, v[\"name\"].encode(\"ascii\", \"ignore\"))\n",
+    "\n",
+    "addons = subset.flatMap(get_ping_addons)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "addon_counts = addons.countByKey()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many addons did the clients have installed in total?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2103048"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "total_addons = sum(addon_counts.values())\n",
+    "total_addons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which whitelisted addons did not appear in the pings?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vertical Tabs\n"
+     ]
+    }
+   ],
+   "source": [
+    "for addon in ADDON_WHITELIST:\n",
+    "    if not addon in addon_counts:\n",
+    "        print ADDON_WHITELIST[addon]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Top whitelisted addons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.217%: Adblock Plus\n",
+      "1.231%: IDM CC\n",
+      "1.084%: Video DownloadHelper\n",
+      "1.017%: Avast Online Security\n",
+      "0.688%: Download YouTube Videos as MP4\n",
+      "0.613%: Firebug\n",
+      "0.553%: YouTube Video and Audio Downloader\n",
+      "0.543%: 1-Click YouTube Video Downloader\n",
+      "0.518%: McAfee WebAdvisor\n",
+      "0.491%: Flash Video Downloader - YouTube HD Download [4K]\n",
+      "0.371%: DownThemAll!\n",
+      "0.329%: Greasemonkey\n",
+      "0.321%: Kaspersky URL Advisor\n",
+      "0.294%: Avira Browser Safety\n",
+      "0.290%: Adblock Plus Pop-up Addon\n",
+      "0.228%: MEGA\n",
+      "0.220%: Yandex Visual Bookmarks\n",
+      "0.213%: Yandex Elements\n",
+      "0.211%: AVG SafeGuard toolbar\n",
+      "0.199%: Ghostery\n",
+      "0.196%: FlashGot\n",
+      "0.170%: WOT\n",
+      "0.154%: NoScript\n",
+      "0.150%: Google Translator for Firefox\n",
+      "0.126%: Pin It button\n",
+      "0.115%: Adblock Edge\n",
+      "0.114%: Element Hiding Helper for Adblock Plus\n",
+      "0.105%: Flagfox\n",
+      "0.101%: Yahoo! Toolbar\n",
+      "0.100%: Download Status Bar\n",
+      "0.099%: Tab Mix Plus\n",
+      "0.089%: IE Tab 2\n",
+      "0.084%: Stylish\n",
+      "0.072%: FireFTP\n",
+      "0.070%: Personas Plus\n",
+      "0.047%: Garmin Communicator\n",
+      "0.043%: Xmarks\n",
+      "0.039%: Flashblock\n",
+      "0.039%: uBlock\n",
+      "0.038%: ColorfulTabs\n",
+      "0.030%: Amazon 1Button App for Firefox\n",
+      "0.025%: HTTPS-Everywhere\n",
+      "0.023%: 1Password\n",
+      "0.010%: LastPass\n",
+      "0.007%: McAfee Security Scan Plus\n",
+      "0.006%: OneTab\n",
+      "0.006%: FoxTab\n",
+      "0.004%: Aol Toolbar\n",
+      "0.001%: Cliqz\n",
+      "0.000%: CCK2\n",
+      "0.000%: GBBD Banco Santander (Brasil) S.A.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "for addon, addon_count in Counter(addon_counts).most_common():\n",
+    "    if addon in ADDON_WHITELIST:\n",
+    "        print \"{:.3f}%: {}\".format(100.0 * addon_count / total_addons, ADDON_WHITELIST[addon])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Top unwhitelisted addons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# An addon ID might have multiple names. Pick the longer one because some addons appear to have\n",
+    "# invalid names (e.g. single space).\n",
+    "addon_names = addons.reduceByKey(lambda a, b: a if len(a) > len(b) else b).collectAsMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "45.211%: Firefox Hello Beta (loop@mozilla.org)\n",
+      "4.637%: Test Pilot (testpilot@labs.mozilla.com)\n",
+      "2.617%: Skype Click to Call ({82AF8DCA-6DE9-405D-BD5E-43525BDAD38A})\n",
+      "0.744%: FromDocToPDF (_65Members_@download.fromdoctopdf.com)\n",
+      "0.672%: SaveFrom.net - helper (helper-sig@savefrom.net)\n",
+      "0.553%: iLivid (LVD-SAE@iacsearchandmedia.com)\n",
+      "0.502%: Module de blocage des sites Internet dangereux (content_blocker@kaspersky.com)\n",
+      "0.495%: anonymoX (client@anonymox.net)\n",
+      "0.443%: Kaspersky Bescherming (light_plugin_D772DC8D6FAF43A29B25C4EBAA5AD1DE@kaspersky.com)\n",
+      "0.426%: Virtualioji klaviatra (virtual_keyboard_07402848C2F6470194F131B0F3DE025E@kaspersky.com)\n",
+      "0.426%: Module de blocage des sites Internet dangereux (content_blocker_663BE84DBCC949E88C7600F63CA7F098@kaspersky.com)\n",
+      "0.409%: goMovix - Movies And More (caa1-aDOiCAxFFMOVIX@jetpack)\n",
+      "0.403%: MySmartPrice (@mysmartprice-ff)\n",
+      "0.399%: Facebook Messenger (www.facebook.com@services.mozilla.org)\n",
+      "0.395%: WeatherBlink (_gcMembers_@www.weatherblink.com)\n",
+      "0.383%: PConverter (_dzMembers_@www.pconverter.com)\n",
+      "0.373%: Music Box (MUB-SAE@iacsearchandmedia.com)\n",
+      "0.359%: Avast SafePrice (sp@avast.com)\n",
+      "0.349%: Sicherer Zahlungsverkehr (online_banking_08806E753BE44495B44E90AA2513BDC5@kaspersky.com)\n",
+      "0.347%: VideoDownloadConverter (_4zMembers_@www.videodownloadconverter.com)\n",
+      "0.328%: Reklam Bal Engelleyicisi (anti_banner@kaspersky.com)\n",
+      "0.325%: Easy Youtube Video Downloader Express ({b9acf540-acba-11e1-8ccb-001fd0e08bd4})\n",
+      "0.324%: Virtuellt tangentbord (virtual_keyboard@kaspersky.com)\n",
+      "0.324%: Sicherer Zahlungsverkehr (online_banking@kaspersky.com)\n",
+      "0.294%: ADB Helper (adbhelper@mozilla.org)\n",
+      "0.255%: Valence (fxdevtools-adapters@mozilla.org)\n",
+      "0.248%: Allin1Convert (_8hMembers_@download.allin1convert.com)\n",
+      "0.242%: Flash and Video Download ({bee6eb20-01e0-ebd1-da83-080329fb9a3a})\n",
+      "0.224%: GamingWonderland (_gtMembers_@free.gamingwonderland.com)\n",
+      "0.197%: Free Games Zone (FGZ-SAE@iacsearchandmedia.com)\n",
+      "0.194%: Ant Video Downloader (anttoolbar@ant.com)\n",
+      "0.187%: Klawiatura wirtualna (virtual_keyboard_294FF26A1D5B455495946778FDE7CEDB@kaspersky.com)\n",
+      "0.187%: Module de blocage des sites Internet dangereux (content_blocker_6418E0D362104DADA084DC312DFA8ABC@kaspersky.com)\n",
+      "0.186%: Internet Speed Tracker (_9tMembers_@download.internetspeedtracker.com)\n",
+      "0.182%: TelevisionFanatic (_64Members_@download.televisionfanatic.com)\n",
+      "0.181%: ProductivityBoss (_e5Members_@www.productivityboss.com)\n",
+      "0.178%: OnlineMapFinder (_9pMembers_@free.onlinemapfinder.com)\n",
+      "0.175%: FilmFanatic (_paMembers_@www.filmfanatic.com)\n",
+      "0.174%: YouTube mp3 (info@youtube-mp3.org)\n",
+      "0.171%: ERail Plugin for Firefox (ERAIL.IN.FFPLUGIN@jetpack)\n",
+      "0.169%: ZenMate Security, Privacy & Unblock VPN (firefox@zenmate.com)\n",
+      "0.167%: YouTube Flash Player (jid1-HAV2inXAnQPIeA@jetpack)\n",
+      "0.166%:  . (sovetnik@metabar.ru)\n",
+      "0.152%: GetFormsOnline (_dbMembers_@free.getformsonline.com)\n",
+      "0.145%: FirefixTab (deskCutv2@gmail.com)\n",
+      "0.142%: Proteccin de Internet 360 (WebProtection@360safe.com)\n",
+      "0.141%: YouTube Flash Video Player ({f3bd3dd2-2888-44c5-91a2-2caeb33fb898})\n",
+      "0.140%: Video Downloader professional (ffext_basicvideoext@startpage24)\n",
+      "0.138%: uBlock Origin (uBlock0@raymondhill.net)\n",
+      "0.138%: Bing Search Engine (bingsearch.full@microsoft.com)\n",
+      "0.134%: Sicherer Zahlungsverkehr (online_banking_69A4E213815F42BD863D889007201D82@kaspersky.com)\n",
+      "0.131%: VideoScavenger (_1eMembers_@www.videoscavenger.com)\n",
+      "0.131%: DownSpeedTest (_dqMembers_@www.downspeedtest.com)\n",
+      "0.125%:   @Mail.Ru ({a38384b3-2d1d-4f36-bc22-0f7ae402bcd7})\n",
+      "0.123%: ReadingFanatic (_6xMembers_@www.readingfanatic.com)\n",
+      "0.118%: Google+ (plus.google.com@services.mozilla.org)\n",
+      "0.115%: Youtube Downloader - 4K Download (paulsaintuzb@gmail.com)\n",
+      "0.113%: Yahoo Mail (mg.mail.yahoo.com@services.mozilla.org)\n",
+      "0.111%:   Mail.Ru (homepage@mail.ru)\n",
+      "0.110%: EPUBReader ({5384767E-00D9-40E9-B72F-9CC39D655D6F})\n",
+      "0.109%: @Mail.Ru (search@mail.ru)\n",
+      "0.105%: musixlib (jid1-lpoiffmusixlib@jetpack)\n",
+      "0.104%: Awesome screenshot: Capture and Annotate (jid0-GXjLLfbCoAx0LcltEdFrEkQdQPI@jetpack)\n",
+      "0.101%: Youtube and more - Easy Video Downloader (vdpure@link64)\n",
+      "0.100%: AdBlock for YouTube (jid1-q4sG8pYhq8KGHs@jetpack)\n",
+      "0.097%: YouTube High Definition ({7b1bf0b6-a1b9-42b0-b75d-252036438bdc})\n",
+      "0.095%: gomusix (ar1er-ewrgfdgomusix@jetpack)\n",
+      "0.093%: Youtube Best Video Downloader 2 ({170503FA-3349-4F17-BC86-001888A5C8E2})\n",
+      "0.091%: YahooToolsProtected (yahooprotected@gmail.com)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for addon, addon_count in Counter(addon_counts).most_common(100):\n",
+    "    if not addon in ADDON_WHITELIST:\n",
+    "        print \"{:.3f}%: {} ({})\".format(100.0 * addon_count / total_addons, addon_names[addon], addon)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/beta45-withaddons/whitelist.py
+++ b/beta45-withaddons/whitelist.py
@@ -1,0 +1,67 @@
+# Fetched from https://wiki.mozilla.org/Electrolysis/Addons
+# Some entries have been commented out because the addon ID could not be determined.
+ADDON_WHITELIST = {
+    # Broken
+    "YoutubeDownloader@PeterOlayev.com":                "1-Click YouTube Video Downloader",
+    "wrc@avast.com":                                    "Avast Online Security",
+    "abs@avira.com":                                    "Avira Browser Safety",
+    "translator@zoli.bod":                              "Google Translator for Firefox",
+    "firefox@ghostery.com":                             "Ghostery",
+    "{3d7eb24f-2740-49df-8937-200b1cc08f8a}":           "Flashblock",
+    "{635abd67-4fe9-1b23-4f01-e679fa7484c1}":           "Yahoo! Toolbar",
+    "{7affbfae-c4e2-4915-8c0f-00fa3ec610a1}":           "Aol Toolbar",
+    "{1BC9BA34-1EED-42ca-A505-6D2F1A935BBB}":           "IE Tab 2",
+
+    # Somewhat working/uses CPOWs
+    "{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}":           "Adblock Plus",
+    "adblockpopups@jessehakanen.net":                   "Adblock Plus Pop-up Addon",
+    "avg@toolbar":                                      "AVG SafeGuard toolbar",
+    "elemhidehelper@adblockplus.org":                   "Element Hiding Helper for Adblock Plus",
+    "{73a6fe31-595d-460b-a920-fcc0f8843232}":           "NoScript",
+    "{19503e42-ca3c-4c27-b1e2-9cdb2170ee34}":           "FlashGot",
+    "mozilla_cc2@internetdownloadmanager.com":          "IDM CC",
+    "yasearch@yandex.ru":                               "Yandex Elements",
+    "support@lastpass.com":                             "LastPass",
+    "{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}":           "WOT",
+    "artur.dubovoy@gmail.com":                          "Flash Video Downloader - YouTube HD Download [4K]",
+    "onepassword4@agilebits.com":                       "1Password",
+
+    # Totally working
+    "cck2wizard@kaply.com":                             "CCK2",
+    "firebug@software.joehewitt.com":                   "Firebug",
+    "{2b10c1c8-a11f-4bad-fe9c-1c11e82cac42}":           "uBlock",
+    "{46551EC9-40F0-4e47-8E18-8E5CF550CFB8}":           "Stylish",
+    "{dc572301-7619-498c-a57d-39143191b318}":           "Tab Mix Plus",
+    "jid1-YcMV6ngYmQRA2w@jetpack":                      "Pin It button",
+    "{e4f94d1e-2f53-401e-8885-681602c0ddd8}":           "McAfee Security Scan Plus",
+    "https-everywhere@eff.org":                         "HTTPS-Everywhere",
+    "url_advisor@kaspersky.com":                        "Kaspersky URL Advisor",
+    "abb@amazon.com":                                   "Amazon 1Button App for Firefox",
+    "{a7c6cf7f-112c-4500-a7ea-39801a327e5f}":           "FireFTP",
+    "personas@christopher.beard":                       "Personas Plus",
+    "mozsocial.cliqz.com@services.mozilla.org":         "Cliqz",
+    "{6c28e999-e900-4635-a39d-b1ec90ba0c0f}":           "Download Status Bar",
+    "{e4a8a97b-f2ed-450b-b12d-ee082ba24781}":           "Greasemonkey",
+    #                                                   "United Internet Addons",
+    "verticaltabs@mozilla.com":                         "Vertical Tabs",
+    "{b9db16a4-6edc-47ec-a1f4-b86292ed211d}":           "Video DownloadHelper",
+    "foxmarks@kei.com":                                 "Xmarks",
+    "{0545b830-f0aa-4d7e-8820-50a4629a56fe}":           "ColorfulTabs",
+    "{b9bfaf1c-a63f-47cd-8b9a-29526ced9060}":           "Download YouTube Videos as MP4",
+    "{DDC359D1-844A-42a7-9AA1-88A850A938A8}":           "DownThemAll!",
+    "{1018e4d6-728f-4b20-ad56-37578a4de76b}":           "Flagfox",
+    "extension@one-tab.com":                            "OneTab",
+    "feca4b87-3be4-43da-a1b1-137c24220968@jetpack":     "YouTube Video and Audio Downloader",
+
+    # Other
+    "firefox@mega.co.nz":                               "MEGA",
+    #                                                   "Norton Toolbar",
+    "{4ED1F68A-5463-4931-9384-8FFF5ED91D92}":           "McAfee WebAdvisor",
+    "vb@yandex.ru":                                     "Yandex Visual Bookmarks",
+    "{ef4e370e-d9f0-4e00-b93e-a4f274cfdd5a}":           "FoxTab",
+    #                                                   "LogMeIn Remote Access",
+    "{195A3098-0BD5-4e90-AE22-BA1C540AFD1E}":           "Garmin Communicator",
+    #                                                   "IBM CCK",
+    "{fe272bd1-5f76-4ea4-8501-a05d35d823fc}":           "Adblock Edge",
+    "{87F8774F-B485-47E2-A755-A40A8A5E8874}":           "GBBD Banco Santander (Brasil) S.A."
+}


### PR DESCRIPTION
The analyses are the same for the most part with the following exceptions:
- `e10s_crash_rate.ipynb` is completely different. It now calculates crashes per 1000 usage hours per build instead of crashes per day.
- `e10s_experiment.ipynb` is mostly the same, but the BHR stuff (`add_gecko_activity`) has been changed to account for child payloads. When there are multiple child payloads in a given ping, the analysis uses the average hangs per minute.