### PR TITLE
Add crash rate analysis for beta45-withoutaddons experiment

### DIFF
--- a/beta45-withoutaddons/e10s_crash_rate.ipynb
+++ b/beta45-withoutaddons/e10s_crash_rate.ipynb
@@ -1,0 +1,430 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### e10s-beta45-withoutaddons: Crash rate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Bug 1222890](https://bugzilla.mozilla.org/show_bug.cgi?id=1222890)\n",
+    "\n",
+    "This analysis compares e10s and non-e10s crash rates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unable to parse whitelist (/home/hadoop/anaconda2/lib/python2.7/site-packages/moztelemetry/bucket-whitelist.json). Assuming all histograms are acceptable.\n",
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ujson as json\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.plotly as py\n",
+    "import IPython\n",
+    "\n",
+    "from __future__ import division\n",
+    "from moztelemetry.spark import get_pings, get_one_ping_per_client, get_pings_properties\n",
+    "from montecarlino import grouped_permutation_test\n",
+    "\n",
+    "%pylab inline\n",
+    "IPython.core.pylabtools.figsize(16, 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "160"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.defaultParallelism"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def is_in_e10s_experiment(ping):\n",
+    "    try:\n",
+    "        experiment = ping[\"environment\"][\"addons\"][\"activeExperiment\"]\n",
+    "        return experiment[\"id\"] == \"e10s-beta45-withoutaddons@experiments.mozilla.org\" and \\\n",
+    "               (experiment[\"branch\"] == \"control-no-addons\" or experiment[\"branch\"] == \"experiment-no-addons\")   \n",
+    "    except:\n",
+    "        return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def is_e10s_ping(ping):\n",
+    "    return ping[\"environment\"][\"settings\"][\"e10sEnabled\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "PING_OPTIONS = {\n",
+    "    \"app\": \"Firefox\",\n",
+    "    \"channel\": \"beta\",\n",
+    "    \"version\": \"45.0\",\n",
+    "    \"build_id\": \"20160211221018\",\n",
+    "    \"submission_date\": (\"20160211\", \"20160216\")\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "main_pings = get_pings(sc, doc_type=\"main\", **PING_OPTIONS).filter(is_in_e10s_experiment).cache()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "defaultdict(int,\n",
+       "            {u'control-no-addons': 729866, u'experiment-no-addons': 662501})"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "main_pings.map(lambda p: (p[\"environment\"][\"addons\"][\"activeExperiment\"][\"branch\"], 0)).countByKey()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "crash_pings = get_pings(sc, doc_type=\"crash\", **PING_OPTIONS).filter(is_in_e10s_experiment).cache()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "defaultdict(int, {u'control-no-addons': 19534, u'experiment-no-addons': 9054})"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crash_pings.map(lambda p: (p[\"environment\"][\"addons\"][\"activeExperiment\"][\"branch\"], 0)).countByKey()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What are the total subsession lengths per build ID?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_subsession_lengths_per_build_id(pings):\n",
+    "    return pings.map(lambda p: (p[\"application\"][\"buildId\"], p[\"payload\"][\"info\"].get(\"subsessionLength\", 0))) \\\n",
+    "                .reduceByKey(lambda a, b: a + b).collectAsMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{u'20160211221018': 2596564535}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e10s_main_pings = main_pings.filter(lambda p: is_e10s_ping(p))\n",
+    "e10s_subsession_lengths = get_subsession_lengths_per_build_id(e10s_main_pings)\n",
+    "e10s_subsession_lengths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{u'20160211221018': 2907700634}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "non_e10s_main_pings = main_pings.filter(lambda p: not is_e10s_ping(p))\n",
+    "non_e10s_subsession_lengths = get_subsession_lengths_per_build_id(non_e10s_main_pings)\n",
+    "non_e10s_subsession_lengths"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What are the total (parent) crash counts per build ID?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_crash_counts_per_build_id(pings):\n",
+    "    return dict(pings.map(lambda p: (p[\"application\"][\"buildId\"], 0)).countByKey())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{u'20160211221018': 8941}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e10s_crash_pings = crash_pings.filter(lambda p: is_e10s_ping(p))\n",
+    "e10s_crash_counts = get_crash_counts_per_build_id(e10s_crash_pings)\n",
+    "e10s_crash_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{u'20160211221018': 19647}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "non_e10s_crash_pings = crash_pings.filter(lambda p: not is_e10s_ping(p))\n",
+    "non_e10s_crash_counts = get_crash_counts_per_build_id(non_e10s_crash_pings)\n",
+    "non_e10s_crash_counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What are the total content crash counts per build ID?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_content_abort_count(ping):\n",
+    "    return ping[\"payload\"].get(\"keyedHistograms\", {}).get(\"SUBPROCESS_ABNORMAL_ABORT\", {}).get(\"content\", {}).get(\"sum\", 0)\n",
+    "\n",
+    "def get_content_crash_count_per_build_id(pings):\n",
+    "    return pings.map(lambda p: (p[\"application\"][\"buildId\"], get_content_abort_count(p))) \\\n",
+    "                .reduceByKey(lambda a, b: a + b).collectAsMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{u'20160211221018': 14409}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e10s_content_crash_counts = get_content_crash_count_per_build_id(e10s_main_pings)\n",
+    "e10s_content_crash_counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Crashes per 1000 usage hours"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "build ID             non-e10s    e10s-parent   e10s-content\n",
+      "20160211221018         24.325         12.396         19.977\n"
+     ]
+    }
+   ],
+   "source": [
+    "SECS_PER_1000_HOURS = 1000 * 60 * 60\n",
+    "print \"build ID             non-e10s    e10s-parent   e10s-content\"\n",
+    "for build_id in sorted(set(e10s_crash_counts.keys()) & set(non_e10s_crash_counts.keys())):\n",
+    "    print \"{} {:>14.3f} {:>14.3f} {:>14.3f}\".format(\n",
+    "        build_id,\n",
+    "        non_e10s_crash_counts[build_id] / non_e10s_subsession_lengths[build_id] * SECS_PER_1000_HOURS,\n",
+    "        e10s_crash_counts[build_id] / e10s_subsession_lengths[build_id] * SECS_PER_1000_HOURS,\n",
+    "        e10s_content_crash_counts[build_id] / e10s_subsession_lengths[build_id] * SECS_PER_1000_HOURS)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
The analysis considers the control-no-addons and experiment-no-addons branches as per bug 1244187 comment 18.