### PR TITLE
Normalize and split GC_REASON_2 per usage hour.

### DIFF
--- a/beta46-apz/e10s_gc_reasons.ipynb
+++ b/beta46-apz/e10s_gc_reasons.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -19,7 +19,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Unable to parse whitelist (/home/hadoop/anaconda2/lib/python2.7/site-packages/moztelemetry/bucket-whitelist.json). Assuming all histograms are acceptable.\n",
       "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/hadoop/anaconda2/lib/python2.7/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
+      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n"
      ]
     }
    ],
@@ -41,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -162,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -173,7 +182,7 @@
        "64"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -195,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -206,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -224,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -235,7 +244,7 @@
        "428576"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -255,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -286,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -297,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -310,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -325,19 +334,46 @@
       "Median difference in 1 per hour is 0.06, (1.03, 0.98).\n",
       "The probablity of this effect being purely by chance is 0.00.\n",
       "\n",
-      "Median difference in 13 per hour is 0.00, (0.00, 0.00).\n",
+      "!E10s has no reports of reason 3. Median of e10s' 3 per hour is 0.00\n",
+      "\n",
+      "Median difference in 4 per hour is 0.00, (0.00, 0.00).\n",
+      "The probablity of this effect being purely by chance is 1.00.\n",
+      "\n",
+      "Median difference in 5 per hour is -1.22, (0.00, 1.22).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 6 per hour is 0.13, (0.98, 0.85).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "E10s has no reports of reason 7. Median of !e10s' 7 per hour is nan\n",
+      "\n",
+      "Median difference in 13 per hour is 0.00, (0.00, 0.00).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/hadoop/anaconda2/lib/python2.7/site-packages/numpy/core/_methods.py:59: RuntimeWarning:\n",
+      "\n",
+      "Mean of empty slice.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "The probablity of this effect being purely by chance is 1.00.\n",
       "\n",
       "Median difference in 14 per hour is 0.43, (4.18, 3.75).\n",
       "The probablity of this effect being purely by chance is 0.00.\n",
       "\n",
       "Median difference in 15 per hour is -0.07, (0.37, 0.44).\n",
-      "The probablity of this effect being purely by chance is 0.18.\n",
+      "The probablity of this effect being purely by chance is 0.17.\n",
       "\n",
       "Median difference in 16 per hour is 0.01, (0.17, 0.16).\n",
-      "The probablity of this effect being purely by chance is 0.24.\n",
-      "\n",
-      "!E10s has no reports of reason 3. Median of e10s' 3 per hour is 0.00\n",
+      "The probablity of this effect being purely by chance is 0.23.\n",
       "\n",
       "!E10s has no reports of reason 33. Median of e10s' 33 per hour is 0.00\n",
       "\n",
@@ -357,9 +393,6 @@
       "The probablity of this effect being purely by chance is 0.07.\n",
       "\n",
       "!E10s has no reports of reason 39. Median of e10s' 39 per hour is 0.00\n",
-      "\n",
-      "Median difference in 4 per hour is 0.00, (0.00, 0.00).\n",
-      "The probablity of this effect being purely by chance is 1.00.\n",
       "\n",
       "Median difference in 40 per hour is 0.96, (1.96, 1.00).\n",
       "The probablity of this effect being purely by chance is 0.00.\n",
@@ -382,9 +415,6 @@
       "Median difference in 49 per hour is 0.00, (0.00, 0.00).\n",
       "The probablity of this effect being purely by chance is 1.00.\n",
       "\n",
-      "Median difference in 5 per hour is -1.22, (0.00, 1.22).\n",
-      "The probablity of this effect being purely by chance is 0.00.\n",
-      "\n",
       "Median difference in 50 per hour is 0.00, (0.00, 0.00).\n",
       "The probablity of this effect being purely by chance is 1.00.\n",
       "\n",
@@ -392,23 +422,23 @@
       "The probablity of this effect being purely by chance is 0.00.\n",
       "\n",
       "Median difference in 52 per hour is -0.00, (1.64, 1.64).\n",
-      "The probablity of this effect being purely by chance is 0.83.\n",
+      "The probablity of this effect being purely by chance is 0.82.\n",
       "\n",
       "Median difference in 53 per hour is 0.00, (0.00, 0.00).\n",
       "The probablity of this effect being purely by chance is 1.00.\n",
-      "\n",
-      "Median difference in 6 per hour is 0.13, (0.98, 0.85).\n",
-      "The probablity of this effect being purely by chance is 0.00.\n",
-      "\n",
-      "E10s has no reports of reason 7. Median of !e10s' 7 per hour is nan\n",
       "\n"
      ]
     }
    ],
    "source": [
+    "reason_nums = set()\n",
     "for reason in e10s_reason_df.columns:\n",
-    "    if reason == \"e10s\":\n",
-    "        continue\n",
+    "    try:\n",
+    "        reason_nums.add(int(reason))\n",
+    "    except:\n",
+    "        pass\n",
+    "for r in sorted(reason_nums):\n",
+    "    reason = str(r)\n",
     "    if len(e10s_reason_df[reason].dropna()) == 0:\n",
     "        print \"E10s has no reports of reason {}. Median of !e10s' {} per hour is {:.2f}\\n\".format(reason, reason, np.median(none10s_reason_df[reason].dropna()))\n",
     "    elif len(none10s_reason_df[reason].dropna()) == 0:\n",

--- a/beta46-apz/e10s_gc_reasons.ipynb
+++ b/beta46-apz/e10s_gc_reasons.ipynb
@@ -1,0 +1,442 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GC Reasons in Firefox Beta46apz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ujson as json\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.plotly as py\n",
+    "import IPython\n",
+    "import re\n",
+    "\n",
+    "from moztelemetry import get_pings, get_pings_properties, get_one_ping_per_client, get_clients_history, Histogram\n",
+    "from montecarlino import grouped_permutation_test\n",
+    "\n",
+    "%pylab inline\n",
+    "IPython.core.pylabtools.figsize(16, 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def chi2_distance(xs, ys, eps = 1e-10, normalize = True):\n",
+    "    histA = xs.sum(axis=0)\n",
+    "    histB = ys.sum(axis=0)\n",
+    "    \n",
+    "    if normalize:\n",
+    "        histA = histA/histA.sum()\n",
+    "        histB = histB/histB.sum()\n",
+    "    \n",
+    "    d = 0.5 * np.sum([((a - b) ** 2) / (a + b + eps)\n",
+    "        for (a, b) in zip(histA, histB)])\n",
+    "\n",
+    "    return d\n",
+    "\n",
+    "def median_diff(xs, ys):\n",
+    "    return np.median(xs) - np.median(ys)\n",
+    "\n",
+    "def compare_histogram(histogram, e10s, none10s):\n",
+    "    # Normalize individual histograms\n",
+    "    e10s = e10s.map(lambda x: x/x.sum())\n",
+    "    none10s = none10s.map(lambda x: x/x.sum())\n",
+    "    if \"BLOCKED_ON_PLUGIN_MODULE_INIT_MS\" in histogram:\n",
+    "        e10s = e10s.map(lambda x: x[x.index > 0])\n",
+    "        none10s = none10s.map(lambda x: x[x.index > 0])\n",
+    "        if e10s.sum().sum() <= 0 or none10s.sum().sum() <= 0:\n",
+    "            return\n",
+    "    \n",
+    "    pvalue = grouped_permutation_test(chi2_distance, [e10s, none10s], num_samples=100)\n",
+    "    \n",
+    "    eTotal = e10s.sum()\n",
+    "    nTotal = none10s.sum()\n",
+    "        \n",
+    "    eTotal = 100*eTotal/eTotal.sum()\n",
+    "    nTotal = 100*nTotal/nTotal.sum()\n",
+    "        \n",
+    "    fig = plt.figure()\n",
+    "    fig.subplots_adjust(hspace=0.3)\n",
+    "        \n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    ax2 = ax.twinx()\n",
+    "    width = 0.4\n",
+    "    ylim = max(eTotal.max(), nTotal.max())\n",
+    "        \n",
+    "    eTotal.plot(kind=\"bar\", alpha=0.5, color=\"green\", label=\"e10s\", ax=ax, width=width, position=0, ylim=(0, ylim + 1))\n",
+    "    nTotal.plot(kind=\"bar\", alpha=0.5, color=\"blue\", label=\"non e10s\", ax=ax2, width=width, position=1, grid=False, ylim=ax.get_ylim())\n",
+    "        \n",
+    "    ax.legend(ax.get_legend_handles_labels()[0] + ax2.get_legend_handles_labels()[0],\n",
+    "              [\"e10s ({} samples\".format(len(e10s)), \"non e10s ({} samples)\".format(len(none10s))])\n",
+    "\n",
+    "    plt.title(histogram)\n",
+    "    plt.xlabel(histogram)\n",
+    "    plt.ylabel(\"Frequency %\")\n",
+    "    plt.show()\n",
+    "        \n",
+    "    print \"The probability that the distributions for {} are differing by chance is {:.2f}.\".format(histogram, pvalue)\n",
+    "\n",
+    "def normalize_uptime_hour(frame):\n",
+    "    frame = frame[frame[\"payload/simpleMeasurements/uptime\"] > 0]\n",
+    "    frame = 60 * frame.apply(lambda x: x/frame[\"payload/simpleMeasurements/uptime\"]) # Metric per hour\n",
+    "    frame.drop('payload/simpleMeasurements/uptime', axis=1, inplace=True)\n",
+    "    return frame\n",
+    "    \n",
+    "def compare_count_histograms(pings, *histograms_names):\n",
+    "    properties = histograms_names + (\"payload/simpleMeasurements/uptime\", \"e10s\")\n",
+    "\n",
+    "    frame = pd.DataFrame(get_pings_properties(pings, properties).collect())\n",
+    "\n",
+    "    e10s = frame[frame[\"e10s\"] == True]\n",
+    "    e10s = normalize_uptime_hour(e10s)\n",
+    "    \n",
+    "    none10s = frame[frame[\"e10s\"] == False]\n",
+    "    none10s = normalize_uptime_hour(none10s)\n",
+    "    \n",
+    "    for histogram in e10s.columns:\n",
+    "        if histogram == \"e10s\" or histogram.endswith(\"_parent\") or histogram.endswith(\"_children\"):\n",
+    "            continue\n",
+    "            \n",
+    "        compare_scalars(histogram + \" per hour\", e10s[histogram].dropna(), none10s[histogram].dropna())\n",
+    "\n",
+    "        \n",
+    "def compare_histograms(pings, *histogram_names):\n",
+    "    frame = pd.DataFrame(get_pings_properties(pings, histogram_names + (\"e10s\",) , with_processes=True).collect())\n",
+    "    compare_df(frame)\n",
+    "    \n",
+    "def compare_df(frame):\n",
+    "    e10s = frame[frame[\"e10s\"] == True]\n",
+    "    none10s = frame[frame[\"e10s\"] == False]\n",
+    "    for histogram in none10s.columns:\n",
+    "        if histogram == \"e10s\" or histogram.endswith(\"_parent\") or histogram.endswith(\"_children\"):\n",
+    "            continue\n",
+    "            \n",
+    "        has_children = np.sum(e10s[histogram + \"_children\"].notnull()) > 0\n",
+    "        has_parent = np.sum(e10s[histogram + \"_parent\"].notnull()) > 0\n",
+    "        \n",
+    "        if has_children and has_parent:\n",
+    "            compare_histogram(histogram + \" (parent + children)\", e10s[histogram].dropna(), none10s[histogram].dropna())\n",
+    "            \n",
+    "        if has_parent:\n",
+    "            compare_histogram(histogram + \" (parent)\", e10s[histogram + \"_parent\"].dropna(), none10s[histogram].dropna())\n",
+    "            \n",
+    "        if has_children:\n",
+    "            compare_histogram(histogram + \" (children)\", e10s[histogram + \"_children\"].dropna(), none10s[histogram].dropna())\n",
+    "                    \n",
+    "\n",
+    "                \n",
+    "def compare_scalars(metric, *groups):\n",
+    "    print \"Median difference in {} is {:.2f}, ({:.2f}, {:.2f}).\".format(metric,\n",
+    "                                                                        median_diff(*groups), \n",
+    "                                                                        np.median(groups[0]),\n",
+    "                                                                        np.median(groups[1]))\n",
+    "    print \"The probablity of this effect being purely by chance is {:.2f}.\\n\". \\\n",
+    "        format(grouped_permutation_test(median_diff, groups, num_samples=10000))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "64"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.defaultParallelism"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dataset = sqlContext.read.load(\"s3://telemetry-parquet/e10s_experiment/e10s_beta46_cohorts/v20160405\", \"parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sampled = dataset.filter(dataset.sampleId <= 30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def row_2_ping(row):\n",
+    "    ping = {\"payload\": {\"simpleMeasurements\": json.loads(row.simpleMeasurements) if row.simpleMeasurements else {},\n",
+    "                        \"histograms\": json.loads(row.histograms) if row.histograms else {},\n",
+    "                        \"keyedHistograms\": json.loads(row.keyedHistograms) if row.keyedHistograms else {},\n",
+    "                        \"childPayloads\": json.loads(row.childPayloads) if row.childPayloads else {},\n",
+    "                        \"threadHangStats\": json.loads(row.threadHangStats)} if row.threadHangStats else {},\n",
+    "           \"e10s\": True if row.e10sCohort == \"test\" else False}\n",
+    "    return ping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "428576"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subset = sampled.rdd.filter(lambda r: r.e10sCohort in [\"test\", \"control\"]).map(row_2_ping)\n",
+    "subset_count = subset.count()\n",
+    "subset_count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For e10s use sum of child payloads' uptimes and reasons. For !e10s, use parent's"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def reason(p):\n",
+    "    out = {\n",
+    "        \"e10s\": p[\"e10s\"],\n",
+    "    }\n",
+    "    if p[\"e10s\"]:\n",
+    "        out[\"payload/simpleMeasurements/uptime\"] = 0;\n",
+    "        for childPayload in p[\"payload\"][\"childPayloads\"]:\n",
+    "            for r in childPayload.get(\"histograms\", {}).get(\"GC_REASON_2\", {}).get(\"values\", {}).iteritems():\n",
+    "                if out.get(r[0], None) is not None:\n",
+    "                    out[r[0]] += r[1]\n",
+    "                else:\n",
+    "                    out[r[0]] = r[1]\n",
+    "            out[\"payload/simpleMeasurements/uptime\"] += childPayload[\"simpleMeasurements\"][\"uptime\"]\n",
+    "    else:\n",
+    "        out[\"payload/simpleMeasurements/uptime\"] = p[\"payload\"][\"simpleMeasurements\"][\"uptime\"]\n",
+    "        for r in p[\"payload\"].get(\"histograms\", {}).get(\"GC_REASON_2\", {}).get(\"values\", {}).iteritems():\n",
+    "            out[r[0]] = r[1]\n",
+    "    \n",
+    "    return out;\n",
+    "\n",
+    "reasons = subset.map(reason)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "reason_df = pd.DataFrame(reasons.collect())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "e10s_reason_df = normalize_uptime_hour(reason_df[reason_df[\"e10s\"] == True])\n",
+    "none10s_reason_df = normalize_uptime_hour(reason_df[reason_df[\"e10s\"] == False])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median difference in 0 per hour is -2.22, (0.00, 2.22).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 1 per hour is 0.06, (1.03, 0.98).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 13 per hour is 0.00, (0.00, 0.00).\n",
+      "The probablity of this effect being purely by chance is 1.00.\n",
+      "\n",
+      "Median difference in 14 per hour is 0.43, (4.18, 3.75).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 15 per hour is -0.07, (0.37, 0.44).\n",
+      "The probablity of this effect being purely by chance is 0.18.\n",
+      "\n",
+      "Median difference in 16 per hour is 0.01, (0.17, 0.16).\n",
+      "The probablity of this effect being purely by chance is 0.24.\n",
+      "\n",
+      "!E10s has no reports of reason 3. Median of e10s' 3 per hour is 0.00\n",
+      "\n",
+      "!E10s has no reports of reason 33. Median of e10s' 33 per hour is 0.00\n",
+      "\n",
+      "Median difference in 34 per hour is 2.08, (5.83, 3.75).\n",
+      "The probablity of this effect being purely by chance is 0.19.\n",
+      "\n",
+      "Median difference in 35 per hour is -7.66, (0.00, 7.66).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 36 per hour is -18.57, (71.43, 90.00).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 37 per hour is -0.20, (1.30, 1.50).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 38 per hour is -0.30, (0.33, 0.63).\n",
+      "The probablity of this effect being purely by chance is 0.07.\n",
+      "\n",
+      "!E10s has no reports of reason 39. Median of e10s' 39 per hour is 0.00\n",
+      "\n",
+      "Median difference in 4 per hour is 0.00, (0.00, 0.00).\n",
+      "The probablity of this effect being purely by chance is 1.00.\n",
+      "\n",
+      "Median difference in 40 per hour is 0.96, (1.96, 1.00).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 41 per hour is 0.00, (0.00, 0.00).\n",
+      "The probablity of this effect being purely by chance is 1.00.\n",
+      "\n",
+      "Median difference in 42 per hour is 0.74, (3.14, 2.40).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 43 per hour is -0.03, (0.18, 0.21).\n",
+      "The probablity of this effect being purely by chance is 0.02.\n",
+      "\n",
+      "Median difference in 47 per hour is -82.86, (188.72, 271.58).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 48 per hour is -392.36, (125.14, 517.50).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 49 per hour is 0.00, (0.00, 0.00).\n",
+      "The probablity of this effect being purely by chance is 1.00.\n",
+      "\n",
+      "Median difference in 5 per hour is -1.22, (0.00, 1.22).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 50 per hour is 0.00, (0.00, 0.00).\n",
+      "The probablity of this effect being purely by chance is 1.00.\n",
+      "\n",
+      "Median difference in 51 per hour is 0.08, (0.48, 0.40).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "Median difference in 52 per hour is -0.00, (1.64, 1.64).\n",
+      "The probablity of this effect being purely by chance is 0.83.\n",
+      "\n",
+      "Median difference in 53 per hour is 0.00, (0.00, 0.00).\n",
+      "The probablity of this effect being purely by chance is 1.00.\n",
+      "\n",
+      "Median difference in 6 per hour is 0.13, (0.98, 0.85).\n",
+      "The probablity of this effect being purely by chance is 0.00.\n",
+      "\n",
+      "E10s has no reports of reason 7. Median of !e10s' 7 per hour is nan\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for reason in e10s_reason_df.columns:\n",
+    "    if reason == \"e10s\":\n",
+    "        continue\n",
+    "    if len(e10s_reason_df[reason].dropna()) == 0:\n",
+    "        print \"E10s has no reports of reason {}. Median of !e10s' {} per hour is {:.2f}\\n\".format(reason, reason, np.median(none10s_reason_df[reason].dropna()))\n",
+    "    elif len(none10s_reason_df[reason].dropna()) == 0:\n",
+    "        print \"!E10s has no reports of reason {}. Median of e10s' {} per hour is {:.2f}\\n\".format(reason, reason, np.median(e10s_reason_df[reason].dropna()))                                                                                            \n",
+    "    else:\n",
+    "        compare_scalars(reason + \" per hour\", e10s_reason_df[reason].dropna(), none10s_reason_df[reason].dropna())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This gives us another way of looking at e10s/none10s differences in GC
slice reasons in case the proportional plot (standard e10s_experiment.ipynb)
is dominated by a couple high-frequency reasons.

bug 1262042